### PR TITLE
Primaries and IPM

### DIFF
--- a/primary.tf
+++ b/primary.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "primary" {
-  count         = "${var.primary_count}"
+  count         = "${var.install_type == "ipm" ? 3 : var.primary_count}"
   ami           = "${var.ami != "" ? var.ami : local.distro_ami}"
   instance_type = "${var.primary_instance_type}"
 

--- a/primary.tf
+++ b/primary.tf
@@ -1,4 +1,7 @@
 resource "aws_instance" "primary" {
+  /* The number of primaries must be hard coded to 3 when Internal Production Mode
+  is selected. Currently, that mode does not support scaling. In other modes, the 
+  cluster can be scaled according the primary_count variable. */
   count         = "${var.install_type == "ipm" ? 3 : var.primary_count}"
   ami           = "${var.ami != "" ? var.ami : local.distro_ami}"
   instance_type = "${var.primary_instance_type}"

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "installer_url" {
 
 variable "primary_count" {
   type        = "string"
-  description = "The number of additional cluster master nodes to run"
+  description = "The number of primary cluster master nodes to run, should be 3 or 5."
   default     = 3
 }
 


### PR DESCRIPTION
When internal production mode is set, the number of primaries needs to be hard set at 3, due to scaling issues with ceph. Otherwise, the value of the count variable will be used.