### PR TITLE
change path for ssh key and config to path.root

### DIFF
--- a/modules/common-user-vpc/ssh-key.tf
+++ b/modules/common-user-vpc/ssh-key.tf
@@ -2,7 +2,7 @@
 ## which has some problems with their label module (recursively included).
 
 locals {
-  ssh_public_key_path = "${path.module}/work"
+  ssh_public_key_path = "${path.root}/work"
   key_name            = "${var.prefix}-${random_string.install_id.result}"
 
   public_key_filename  = "${local.ssh_public_key_path}/${local.key_name}.pub"

--- a/modules/common-with-base-vpc/ssh-key.tf
+++ b/modules/common-with-base-vpc/ssh-key.tf
@@ -2,7 +2,7 @@
 ## which has some problems with their label module (recursively included).
 
 locals {
-  ssh_public_key_path = "${path.module}/work"
+  ssh_public_key_path = "${path.root}/work"
   key_name            = "ptfe-${random_string.install_id.result}"
 
   public_key_filename  = "${local.ssh_public_key_path}/${local.key_name}.pub"

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "installer_dashboard_url" {
 
 ## this allows the user to do `ssh -F ssh-config default`
 resource "local_file" "ssh_config" {
-  filename = "${path.module}/work/ssh-config"
+  filename = "${path.root}/work/ssh-config"
   content  = "${data.template_file.ssh_config.rendered}"
 }
 


### PR DESCRIPTION
# Background

In testing and using the module, the path to the ssh config file and the ssh private key end up being very deep from the working directory buried inside the local module cache, this change is to update so that the files are created in `{cwd}/work/...` instead of `{cwd}/.terraform/modules/{invocation_id}/work/...`

## This PR makes me feel
![Cut down tree falling and causing other trees to also fall](https://media2.giphy.com/media/NjtaK21HsFt4Y/giphy.gif?cid=6104955e859dc3dd2c42326c65cfdcadaf60ce276c30fd04&rid=giphy.gif)
