### PR TITLE
Custom Weave & Repl Service CIDR bits 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Please contact your Technical Account Manager for more information, and support 
 | primary\_instance\_type | ec2 instance type | string | `"m4.xlarge"` | no |
 | ptfe\_url | URL to the PTFE tool | string | `"https://install.terraform.io/installer/ptfe.zip"` | no |
 | region | aws region where resources will be created | string | `"us-west-2"` | no |
+| repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is `10.96.0.0/12` | string | `""` | no |
 | s3\_bucket | S3 bucket to store objects into | string | `""` | no |
 | s3\_region | Region of the S3 bucket | string | `""` | no |
 | secondary\_instance\_type | ec2 instance type (Defaults to `primary_instance_type` if not set.) | string | `""` | no |
@@ -56,7 +57,6 @@ Please contact your Technical Account Manager for more information, and support 
 | update\_route53 | whether or not to automatically update route53 records for the cluster | string | `"true"` | no |
 | volume\_size | size of the root volume in gb | string | `"100"` | no |
 | weave\_cidr | Specify a non-standard CIDR range for weave. The default is `172.18.0.0/16` | string | `""` | no |
-| repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is `10.96.0.0/12` | string | `""` | no |
 | whitelist | List of CIDRs we allow to access the PTFE infrastructure | list | `[]` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Please contact your Technical Account Manager for more information, and support 
 | subnet\_tags | tags to use to match subnets to use | map | `{}` | no |
 | update\_route53 | whether or not to automatically update route53 records for the cluster | string | `"true"` | no |
 | volume\_size | size of the root volume in gb | string | `"100"` | no |
+| weave\_cidr | Specify a non-standard CIDR range for weave. The default is `172.18.0.0/16` | string | `""` | no |
+| repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is `10.96.0.0/12` | string | `""` | no |
 | whitelist | List of CIDRs we allow to access the PTFE infrastructure | list | `[]` | no |
 
 ## Outputs

--- a/config.tf
+++ b/config.tf
@@ -52,6 +52,8 @@ data "template_file" "cloud_config" {
     health_url           = "http://${aws_elb.cluster_api.dns_name}:${local.assistant_port}/healthz"
     proxy_url            = "${var.http_proxy_url}"
     installer_url        = "${var.installer_url}"
+    weave_cidr           = "${var.weave_cidr}"
+    repl_cidr            = "${var.repl_cidr}"
 
     ca_cert_url = "${var.ca_cert_url}"
 

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -46,6 +46,8 @@ export role
 
 airgap_url_path="/etc/ptfe/airgap-package-url"
 airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
+weave_cidr="/etc/ptfe/weave_cidr"
+repl_cidr="/etc/ptfe/repl_cidr"
 
 # ------------------------------------------------------------------------------
 # Custom CA certificate download and configuration block
@@ -132,6 +134,18 @@ if [ "x${role}x" == "xmainx" ]; then
         ptfe_install_args+=(
             --airgap-installer /var/lib/ptfe/replicated.tar.gz
         )
+    fi
+
+    if test -e "$weave_cidr"; then
+      ptfe_install_args+=(
+          "--weaveCIDR=$(cat /etc/ptfe/weave_cidr)"
+      )
+    fi
+
+    if test -e "$repl_cidr"; then
+      ptfe_install_args+=(
+          "--replCIDR=$(cat /etc/ptfe/repl_cidr)"
+      )
     fi
 fi
 

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -102,6 +102,20 @@ write_files:
   permissions: "0644"
   content: ${airgap_installer_url}
 %{ endif }
+
+%{ if weave_cidr != "" }
+- path: /etc/ptfe/weave-cidr
+  owner: root:root
+  permissions: "0644"
+  content: ${weave_cidr}
+%{ endif }
+
+%{ if repl_cidr != "" }
+- path: /etc/ptfe/repl-cidr
+  owner: root:root
+  permissions: "0644"
+  content: ${repl_cidr}
+%{ endif }
 %{ endif }
 %{ if distro == "ubuntu" }
 - path: /etc/apt/apt.conf.d/00_aaa_proxy.conf

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,18 @@ variable "volume_size" {
   default     = "100"
 }
 
+variable "weave_cidr" {
+  type        = "string"
+  description = "Specify a non-standard CIDR range for weave. The default is 172.18.0.0/16"
+  default     = ""
+}
+
+variable "repl_cidr" {
+  type        = "string"
+  description = "Specify a non-standard CIDR range for the replicated services. The default is 10.96.0.0/12"
+  default     = ""
+}
+
 ### ================================ External Services Support
 
 variable "aws_access_key_id" {


### PR DESCRIPTION
This allows a module user to specify a custom CIDR range for weave to use or the replicated service. It was discovered many moons ago that if the default CIDR range is already in use, you can break k8s in new and fun ways. Changes to the ptfe installer previously made, this change exposes this feature in the module to end users.