### PR TITLE
Fix custom Weave and Replicated CIDRs for new ptfe tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please contact your Technical Account Manager for more information, and support 
 | subnet\_tags | tags to use to match subnets to use | map | `{}` | no |
 | update\_route53 | whether or not to automatically update route53 records for the cluster | string | `"true"` | no |
 | volume\_size | size of the root volume in gb | string | `"100"` | no |
-| weave\_cidr | Specify a non-standard CIDR range for weave. The default is `172.18.0.0/16` | string | `""` | no |
+| weave\_cidr | Specify a non-standard CIDR range for weave. The default is `10.32.0.0/12` | string | `""` | no |
 | whitelist | List of CIDRs we allow to access the PTFE infrastructure | list | `[]` | no |
 
 ## Outputs

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -46,8 +46,8 @@ export role
 
 airgap_url_path="/etc/ptfe/airgap-package-url"
 airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
-weave_cidr="/etc/ptfe/weave_cidr"
-repl_cidr="/etc/ptfe/repl_cidr"
+weave_cidr="/etc/ptfe/weave-cidr"
+repl_cidr="/etc/ptfe/repl-cidr"
 
 # ------------------------------------------------------------------------------
 # Custom CA certificate download and configuration block
@@ -138,13 +138,13 @@ if [ "x${role}x" == "xmainx" ]; then
 
     if test -e "$weave_cidr"; then
       ptfe_install_args+=(
-          "--weaveCIDR=$(cat /etc/ptfe/weave_cidr)"
+          "--ip-alloc-range=$(cat /etc/ptfe/weave-cidr)"
       )
     fi
 
     if test -e "$repl_cidr"; then
       ptfe_install_args+=(
-          "--replCIDR=$(cat /etc/ptfe/repl_cidr)"
+          "--service-cidr=$(cat /etc/ptfe/repl-cidr)"
       )
     fi
 fi
@@ -170,5 +170,5 @@ if [ "x${role}x" == "xsecondaryx" ]; then
 fi
 
 
-
+echo "Running 'ptfe install $verb ${ptfe_install_args[@]}'"
 ptfe install $verb "${ptfe_install_args[@]}"

--- a/variables.tf
+++ b/variables.tf
@@ -176,7 +176,7 @@ variable "volume_size" {
 
 variable "weave_cidr" {
   type        = "string"
-  description = "Specify a non-standard CIDR range for weave. The default is 172.18.0.0/16"
+  description = "Specify a non-standard CIDR range for weave. The default is 10.32.0.0/12"
   default     = ""
 }
 


### PR DESCRIPTION
As we upgraded to Replicated 2.39.0 in the `ptfe` tool we ran into an issue where there was a conflict with the default we introduced before we could customize the CIDR that Weave uses. Now that this feature exists we don't need the patched in default but it turns out that the installer wasn't using the correct flags for the `ptfe` tool to pass the ip allocation (`--weaveCIDR` vs `--ip-alloc-range` and `--replCIDR` vs `--service-cidr`, the latter being the correct ones). Similarly the filenames shifted a bit so it was often checking for a file that didn't exist. Likely a case where the ptfe tool updated the flags but got missed in the installers. 

Finally, since we removed the default CIDR in the Replicated installer I updated comment/docs to show the Replicated default for Weave. 🎉 