### PR TITLE
Provide a basic external services module

### DIFF
--- a/modules/external-services/README.md
+++ b/modules/external-services/README.md
@@ -1,0 +1,10 @@
+## Terraform Enterprise External Services
+
+This module provides basic AWS external service resources in the form of:
+
+* An S3 bucket
+* An IAM user that can access the S3 bucket
+* An Aurora cluster with a single instance in Postgresql mode
+
+This module assumes basic setup with reasonable defaults. If need extensive changes,
+best to copy this module and make your own local changes to it.

--- a/modules/external-services/iam.tf
+++ b/modules/external-services/iam.tf
@@ -1,0 +1,30 @@
+resource "aws_iam_user" "tfe_objects" {
+  name          = "${var.prefix}tfe-object-store-${var.install_id}"
+  force_destroy = true
+}
+
+## credentials to be passed to archivist
+resource "aws_iam_access_key" "tfe_objects" {
+  user = "${aws_iam_user.tfe_objects.name}"
+}
+
+resource "aws_iam_user_policy" "tfe_objects" {
+  user = "${aws_iam_user.tfe_objects.name}"
+  name = "${var.prefix}archivist-bucket-${var.install_id}"
+
+  policy = <<__policy
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Resource": [
+            "arn:aws:s3:::${aws_s3_bucket.tfe_objects.id}",
+            "arn:aws:s3:::${aws_s3_bucket.tfe_objects.id}/*"
+        ],
+        "Effect": "Allow",
+        "Action": [
+            "s3:*"
+        ]
+    }]
+}
+__policy
+}

--- a/modules/external-services/main.tf
+++ b/modules/external-services/main.tf
@@ -1,0 +1,37 @@
+### =================================================================== REQUIRED
+
+variable "vpc_id" {
+  type        = "string"
+  description = "AWS VPC id to install into"
+}
+
+variable "install_id" {
+  type        = "string"
+  description = "Identifier for installation"
+}
+
+### =================================================================== OPTIONAL
+
+variable "prefix" {
+  type        = "string"
+  description = "string to prefix all resources with "
+  default     = ""
+}
+
+variable "rds_subnet_tags" {
+  type        = "map"
+  description = "tags to use to match subnets to use"
+  default     = {}
+}
+
+variable "database_name" {
+  type        = "string"
+  description = "name of the initial database"
+  default     = "tfe"
+}
+
+variable "database_username" {
+  type        = "string"
+  description = "username of the initial user"
+  default     = "tfe"
+}

--- a/modules/external-services/output.tf
+++ b/modules/external-services/output.tf
@@ -1,0 +1,31 @@
+output "iam_access_key" {
+  value = "${aws_iam_access_key.tfe_objects.id}"
+}
+
+output "iam_secret_key" {
+  value = "${aws_iam_access_key.tfe_objects.secret}"
+}
+
+output "s3_bucket" {
+  value = "${aws_s3_bucket.tfe_objects.id}"
+}
+
+output "s3_region" {
+  value = "${aws_s3_bucket.tfe_objects.region}"
+}
+
+output "database_password" {
+  value = "${random_string.database_password.result}"
+}
+
+output "database_username" {
+  value = "${var.database_username}"
+}
+
+output "database_endpoint" {
+  value = "${aws_rds_cluster.tfe.endpoint}"
+}
+
+output "database_name" {
+  value = "${var.database_name}"
+}

--- a/modules/external-services/rds.tf
+++ b/modules/external-services/rds.tf
@@ -1,0 +1,65 @@
+locals {
+  postgres_port = "5432"
+}
+
+data "aws_vpc" "selected" {
+  id = "${var.vpc_id}"
+}
+
+data "aws_subnet_ids" "rds" {
+  vpc_id = "${var.vpc_id}"
+  tags   = "${var.rds_subnet_tags}"
+}
+
+data "aws_subnet" "selected" {
+  count = "${length(data.aws_subnet_ids.rds.ids)}"
+  id    = "${data.aws_subnet_ids.rds.ids[count.index]}"
+}
+
+resource "aws_security_group" "db_access" {
+  description = "allow instances to talk to each other, and have unfettered egress"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    protocol  = "tcp"
+    from_port = "${local.postgres_port}"
+    to_port   = "${local.postgres_port}"
+
+    cidr_blocks = ["${data.aws_subnet.selected.*.cidr_block}"]
+  }
+}
+
+resource "random_string" "database_password" {
+  length  = 40
+  special = false
+}
+
+resource "aws_db_subnet_group" "tfe" {
+  name       = "${var.prefix}tfe"
+  subnet_ids = ["${data.aws_subnet.selected.*.id}"]
+
+  tags = {
+    Name = "tfe subnet group"
+  }
+}
+
+resource "aws_rds_cluster" "tfe" {
+  cluster_identifier_prefix = "${var.prefix}tfe"
+  engine                    = "aurora-postgresql"
+  database_name             = "${var.database_name}"
+  master_username           = "${var.database_username}"
+  master_password           = "${random_string.database_password.result}"
+  db_subnet_group_name      = "${aws_db_subnet_group.tfe.name}"
+  backup_retention_period   = 5
+  preferred_backup_window   = "07:00-09:00"
+  vpc_security_group_ids    = ["${aws_security_group.db_access.id}"]
+}
+
+resource "aws_rds_cluster_instance" "tfe1" {
+  apply_immediately    = true
+  cluster_identifier   = "${aws_rds_cluster.tfe.id}"
+  identifier_prefix    = "${var.prefix}tfe1"
+  engine               = "aurora-postgresql"
+  instance_class       = "db.r5.large"
+  db_subnet_group_name = "${aws_db_subnet_group.tfe.name}"
+}

--- a/modules/external-services/rds.tf
+++ b/modules/external-services/rds.tf
@@ -35,8 +35,8 @@ resource "random_string" "database_password" {
 }
 
 resource "aws_db_subnet_group" "tfe" {
-  name       = "${var.prefix}tfe"
-  subnet_ids = ["${data.aws_subnet.selected.*.id}"]
+  name_prefix = "${var.prefix}tfe-${var.install_id}"
+  subnet_ids  = ["${data.aws_subnet.selected.*.id}"]
 
   tags = {
     Name = "tfe subnet group"

--- a/modules/external-services/rds.tf
+++ b/modules/external-services/rds.tf
@@ -44,7 +44,7 @@ resource "aws_db_subnet_group" "tfe" {
 }
 
 resource "aws_rds_cluster" "tfe" {
-  cluster_identifier_prefix = "${var.prefix}tfe"
+  cluster_identifier_prefix = "${var.prefix}tfe-${var.install_id}"
   engine                    = "aurora-postgresql"
   database_name             = "${var.database_name}"
   master_username           = "${var.database_username}"
@@ -53,6 +53,7 @@ resource "aws_rds_cluster" "tfe" {
   backup_retention_period   = 5
   preferred_backup_window   = "07:00-09:00"
   vpc_security_group_ids    = ["${aws_security_group.db_access.id}"]
+  final_snapshot_identifier = "${var.prefix}tfe-${var.install_id}-final"
 }
 
 resource "aws_rds_cluster_instance" "tfe1" {

--- a/modules/external-services/s3.tf
+++ b/modules/external-services/s3.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "tfe_objects" {
+  bucket = "${var.prefix}tfe-${var.install_id}"
+}


### PR DESCRIPTION
This module sets up basic external services in AWS. It assumes basic setup with reasonable defaults and can be used for production deployments.

Users that need extensive changes are directed to copy the module into their own module and make the changes locally.