### PR TITLE
Download airgap installer everywhere and use ptfe util download to do so

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -96,6 +96,8 @@ data "template_file" "cloud_config_secondary" {
     installer_url        = "${var.installer_url}"
     role                 = "secondary"
 
+    airgap_installer_url = "${var.airgap_installer_url}"
+
     ca_bundle_url = "${var.ca_bundle_url}"
 
     import_key = "${var.import_key}"

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -127,13 +127,10 @@ if [ "x${role}x" == "xmainx" ]; then
     if test -e "$airgap_url_path"; then
         mkdir -p /var/lib/ptfe
         pushd /var/lib/ptfe
-        curl -sfSL -o /var/lib/ptfe/ptfe.airgap "$(< "$airgap_url_path")"
-        curl -sfSL -o /var/lib/ptfe/replicated.tar.gz "$(< "$airgap_installer_url_path")"
+        airgap_url="$(< "$airgap_url_path")"
+        echo "Downloading airgap package from $airgap_url"
+        ptfe util download "$airgap_url" /var/lib/ptfe/ptfe.airgap
         popd
-
-        ptfe_install_args+=(
-            --airgap-installer /var/lib/ptfe/replicated.tar.gz
-        )
     fi
 
     if test -e "$weave_cidr"; then
@@ -169,6 +166,18 @@ if [ "x${role}x" == "xsecondaryx" ]; then
     export verb
 fi
 
+if test -e "$airgap_installer_url_path"; then
+    mkdir -p /var/lib/ptfe
+    pushd /var/lib/ptfe
+    airgap_installer_url="$(< "$airgap_installer_url_path")"
+    echo "Downloading airgap installer from $airgap_installer_url"
+    ptfe util download "$airgap_installer_url" /var/lib/ptfe/replicated.tar.gz
+    popd
+
+    ptfe_install_args+=(
+        --airgap-installer /var/lib/ptfe/replicated.tar.gz
+    )
+fi
 
 echo "Running 'ptfe install $verb ${ptfe_install_args[@]}'"
 ptfe install $verb "${ptfe_install_args[@]}"

--- a/templates/cloud-config-secondary.yaml
+++ b/templates/cloud-config-secondary.yaml
@@ -29,6 +29,13 @@ write_files:
   permissions: "0400"
   content: "${health_url}"
 
+%{ if airgap_installer_url != "" }
+- path: /etc/ptfe/airgap-installer-url
+  owner: root:root
+  permissions: "0644"
+  content: ${airgap_installer_url}
+%{ endif }
+
 - path: /var/lib/cloud/scripts/per-once/install-ptfe.sh
   owner: root:root
   permissions: "0555"

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -71,6 +71,14 @@ write_files:
     export http_proxy="${proxy_url}"
     export https_proxy="${proxy_url}"
     export no_proxy=10.0.0.0/8,127.0.0.1,169.254.169.254
+
+%{ if airgap_installer_url != "" }
+- path: /etc/ptfe/airgap-installer-url
+  owner: root:root
+  permissions: "0644"
+  content: ${airgap_installer_url}
+%{ endif }
+
 %{ if role == "main" }
 - path: /etc/replicated.rli
   owner: root:root
@@ -96,11 +104,6 @@ write_files:
   owner: root:root
   permissions: "0644"
   content: ${airgap_package_url}
-
-- path: /etc/ptfe/airgap-installer-url
-  owner: root:root
-  permissions: "0644"
-  content: ${airgap_installer_url}
 %{ endif }
 
 %{ if weave_cidr != "" }
@@ -117,6 +120,7 @@ write_files:
   content: ${repl_cidr}
 %{ endif }
 %{ endif }
+
 %{ if distro == "ubuntu" }
 - path: /etc/apt/apt.conf.d/00_aaa_proxy.conf
   owner: root:root

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "prefix" {
 variable "airgap_installer_url" {
   type        = "string"
   description = "URL to airgap installer package"
-  default     = "https://install.terraform.io/installer/replicated-v5.tar.gz"
+  default     = "https://s3.amazonaws.com/replicated-airgap-work/replicated__docker__kubernetes.tar.gz"
 }
 
 variable "airgap_package_url" {


### PR DESCRIPTION
To bits here:

1. This threads through the airgap_installer_url to all the nodes if airgap is used, so they can download it to bootstrap the kubernetes components properly.

2. It uses https://github.com/hashicorp/ptfe/pull/38 to download both the airgap installer and the airgap file itself. This new tool supports http/https urls like curl as well as s3, allowing the AWS modules to use s3 urls for the assets.