### PR TITLE
Only run the Custom CA Bundle setup function on the main server

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -100,7 +100,7 @@ if [ "x${role}x" == "xmainx" ]; then
     # Custom CA certificate download and configuration block
     # ------------------------------------------------------------------------------
     if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
-          $(< /etc/ptfe/custom-ca-cert-url)  none ]]; then
+          $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
       custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
       custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
       ca_tmp_dir="/tmp/ptfe-customer-certs"

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -105,7 +105,7 @@ if [ "x${role}x" == "xmainx" ]; then
       custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
       ca_tmp_dir="/tmp/ptfe-customer-certs"
       replicated_conf_file="replicated-ptfe.conf"
-      local_messages_file="/var/log/tfe-custom-cert-install.log"
+      local_messages_file="local_messages.log"
       # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
       # since we're trusting user input to be both a working URL and a valid certificate.
       # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -103,12 +103,12 @@ if [ "x${role}x" == "xmainx" ]; then
     # Custom CA certificate download and configuration block
     # ------------------------------------------------------------------------------
     if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
-          $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
+          $(< /etc/ptfe/custom-ca-cert-url)  none ]]; then
       custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
       custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
       ca_tmp_dir="/tmp/ptfe-customer-certs"
       replicated_conf_file="replicated-ptfe.conf"
-      local_messages_file="local_messages.log"
+      local_messages_file="/var/log/tfe-custom-cert-install.log"
       # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
       # since we're trusting user input to be both a working URL and a valid certificate.
       # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.

--- a/modules/external-services/rds.tf
+++ b/modules/external-services/rds.tf
@@ -35,8 +35,8 @@ resource "random_string" "database_password" {
 }
 
 resource "aws_db_subnet_group" "tfe" {
-  name       = "${var.prefix}tfe"
-  subnet_ids = ["${data.aws_subnet.selected.*.id}"]
+  name_prefix = "${var.prefix}tfe-${var.install_id}"
+  subnet_ids  = ["${data.aws_subnet.selected.*.id}"]
 
   tags = {
     Name = "tfe subnet group"


### PR DESCRIPTION
Came up in testing where other nodes could not join the cluster as they were attempting to setup a custom ca bundle which mutates the `replicated-ptfe.conf` but that file is only placed on the first server (which we refer to as "main" in the scripts). 

This PR moves the setup of the bundle into the area of setup that only runs on main which fixes the issue. 