### PR TITLE
Sideload the replicated installer tar.gz

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -51,11 +51,17 @@ repl_cidr="/etc/ptfe/repl-cidr"
 
 
 
+
+health_url="$(cat /etc/ptfe/health-url)"
+role_id="$(cat /etc/ptfe/role-id)"
+
 ptfe_install_args=(
     -DD
     "--bootstrap-token=$(cat /etc/ptfe/bootstrap-token)" \
     "--cluster-api-endpoint=$(cat /etc/ptfe/cluster-api-endpoint)" \
-    --health-url "$(cat /etc/ptfe/health-url)"
+    --health-url "$health_url"
+    --assistant-host "$(cat /etc/ptfe/assistant-host)"
+    --assistant-token "$(cat /etc/ptfe/assistant-token)"
 )
 
 if [ "x${role}x" == "xmainx" ]; then
@@ -146,12 +152,17 @@ if [ "x${role}x" == "xmainx" ]; then
 
       popd
     fi
+else
+    # We do this before continuing so that the airgap_installer_url can reference
+    # the internal load balancer and retrieve files from the primary
+    echo "Waiting for cluster to start before continuing..."
+    ptfe install join --role-id "$role_id" --health-url "$health_url" --wait-for-cluster
 fi
 
 if [ "x${role}x" != "xsecondaryx" ]; then
     ptfe_install_args+=(
         --primary-pki-url "$(cat /etc/ptfe/primary-pki-url)"
-        --role-id "$(cat /etc/ptfe/role-id)"
+        --role-id "$role_id"
     )
 fi
 

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -53,7 +53,6 @@ repl_cidr="/etc/ptfe/repl-cidr"
 
 
 health_url="$(cat /etc/ptfe/health-url)"
-role_id="$(cat /etc/ptfe/role-id)"
 
 ptfe_install_args=(
     -DD
@@ -63,6 +62,16 @@ ptfe_install_args=(
     --assistant-host "$(cat /etc/ptfe/assistant-host)"
     --assistant-token "$(cat /etc/ptfe/assistant-token)"
 )
+
+role_id=0
+
+if test -e /etc/ptfe/role-id; then
+    role_id="$(cat /etc/ptfe/role-id)"
+    ptfe_install_args+=(
+        --role-id "$role_id"
+    )
+fi
+
 
 if [ "x${role}x" == "xmainx" ]; then
     verb="setup"
@@ -162,7 +171,6 @@ fi
 if [ "x${role}x" != "xsecondaryx" ]; then
     ptfe_install_args+=(
         --primary-pki-url "$(cat /etc/ptfe/primary-pki-url)"
-        --role-id "$role_id"
     )
 fi
 

--- a/templates/cloud-config-secondary.yaml
+++ b/templates/cloud-config-secondary.yaml
@@ -29,6 +29,16 @@ write_files:
   permissions: "0400"
   content: "${health_url}"
 
+- path: /etc/ptfe/assistant-host
+  owner: root:root
+  permissions: "0400"
+  content: "${assistant_host}"
+
+- path: /etc/ptfe/assistant-token
+  owner: root:root
+  permissions: "0400"
+  content: "${assistant_token}"
+
 %{ if airgap_installer_url != "" }
 - path: /etc/ptfe/airgap-installer-url
   owner: root:root

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -43,6 +43,16 @@ write_files:
   permissions: "0400"
   content: "${health_url}"
 
+- path: /etc/ptfe/assistant-host
+  owner: root:root
+  permissions: "0400"
+  content: "${assistant_host}"
+
+- path: /etc/ptfe/assistant-token
+  owner: root:root
+  permissions: "0400"
+  content: "${assistant_token}"
+
 - path: /etc/ptfe/role-id
   owner: root:root
   permissions: "0444"


### PR DESCRIPTION
The replicated airgap tar.gz file in huge, like 5GB. This change allows the non initial nodes to load that tar.gz directly from the initial primary (and in reality any properly booted primary once the cluster is up and stable).