### PR TITLE
Support Replicated Release Sequence to allow version pinning

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -50,6 +50,8 @@ data "template_file" "cloud_config" {
     license_b64     = "${base64encode(file("${var.license_file}"))}"
     install_ptfe_sh = "${base64encode(file("${path.module}/files/install-ptfe.sh"))}"
 
+    release_sequence      = "${var.release_sequence}"
+
     # Needed for Airgap installations
     airgap_package_url   = "${var.airgap_package_url}"
     airgap_installer_url = "${var.airgap_package_url == "" ? "" : count.index == 0 ? var.airgap_installer_url : local.internal_airgap_url}"

--- a/config.tf
+++ b/config.tf
@@ -33,6 +33,7 @@ data "template_file" "repl_config" {
   vars = {
     console_password = "${random_pet.console_password.id}"
     proxy_url        = "${var.http_proxy_url}"
+    release_sequence = "${var.release_sequence}"
   }
 }
 
@@ -49,8 +50,6 @@ data "template_file" "cloud_config" {
 
     license_b64     = "${base64encode(file("${var.license_file}"))}"
     install_ptfe_sh = "${base64encode(file("${path.module}/files/install-ptfe.sh"))}"
-
-    release_sequence      = "${var.release_sequence}"
 
     # Needed for Airgap installations
     airgap_package_url   = "${var.airgap_package_url}"

--- a/data/airgap_replicated.json
+++ b/data/airgap_replicated.json
@@ -7,4 +7,7 @@
   "LicenseFileLocation"               : "/etc/replicated.rli",
   "LicenseBootstrapAirgapPackagePath" : "/var/lib/ptfe/ptfe.airgap",
   "HttpProxy"                         : "${proxy_url}"
+  %{ if release_sequence != "" }
+  ,"ReleaseSequence":             ${release_sequence}
+  %{ endif }
 }

--- a/data/demo_replicated.json
+++ b/data/demo_replicated.json
@@ -6,4 +6,7 @@
     "ImportSettingsFrom":           "/etc/replicated-ptfe.conf",
     "LicenseFileLocation":          "/etc/replicated.rli",
     "HttpProxy":                    "${proxy_url}"
+    %{ if release_sequence != "" }
+    ,"ReleaseSequence":             ${release_sequence}
+    %{ endif }
 }

--- a/data/es_airgap_replicated.json
+++ b/data/es_airgap_replicated.json
@@ -6,4 +6,7 @@
     "ImportSettingsFrom":           "/etc/replicated-ptfe.conf",
     "LicenseFileLocation":          "/etc/replicated.rli",
     "LicenseBootstrapAirgapPackagePath" : "/var/lib/ptfe/ptfe.airgap"
+    %{ if release_sequence != "" }
+    ,"ReleaseSequence":             ${release_sequence}
+    %{ endif }
 }

--- a/data/es_replicated.json
+++ b/data/es_replicated.json
@@ -6,4 +6,7 @@
     "ImportSettingsFrom":           "/etc/replicated-ptfe.conf",
     "LicenseFileLocation":          "/etc/replicated.rli",
     "HttpProxy":                    "${proxy_url}"
+    %{ if release_sequence != "" }
+    ,"ReleaseSequence":             ${release_sequence}
+    %{ endif }
 }

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -31,6 +31,7 @@
 | prefix | Name prefix for resource names and tags | string | `"tfe"` | no |
 | primary\_count | The number of primary cluster master nodes to run, only 3 support now. | string | `"3"` | no |
 | primary\_instance\_type | ec2 instance type | string | `"m4.xlarge"` | no |
+| release_sequence | Replicated release sequence | string | `""` | no |
 | repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is 10.96.0.0/12 | string | `""` | no |
 | s3\_bucket | S3 bucket to store objects into | string | `""` | no |
 | s3\_region | Region of the S3 bucket | string | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -102,12 +102,6 @@ variable "installer_url" {
   default     = "https://install.terraform.io/installer/ptfe-0.1.zip"
 }
 
-variable "release_sequence" {
-  type        = "string"
-  description = "Replicated release sequence number to install - this locks the install to a specific release"
-  default     = ""
-}
-
 variable "primary_count" {
   type        = "string"
   description = "The number of primary cluster master nodes to run, only 3 support now."
@@ -165,6 +159,11 @@ variable "volume_size" {
 variable "weave_cidr" {
   type        = "string"
   description = "Specify a non-standard CIDR range for weave. The default is 10.32.0.0/12"
+  default     = ""
+}
+variable "release_sequence" {
+  type        = "string"
+  description = "Replicated release sequence number to install - this locks the install to a specific release"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "installer_url" {
   default     = "https://install.terraform.io/installer/ptfe-0.1.zip"
 }
 
+variable "release_sequence" {
+  type        = "string"
+  description = "Replicated release sequence number to install - this locks the install to a specific release"
+  default     = ""
+}
+
 variable "primary_count" {
   type        = "string"
   description = "The number of primary cluster master nodes to run, only 3 support now."

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,7 @@ variable "weave_cidr" {
   description = "Specify a non-standard CIDR range for weave. The default is 10.32.0.0/12"
   default     = ""
 }
+
 variable "release_sequence" {
   type        = "string"
   description = "Replicated release sequence number to install - this locks the install to a specific release"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-aws-terraform-enterprise/issues/30. 

As mentioned in https://github.com/hashicorp/terraform-aws-terraform-enterprise/issues/30#issuecomment-548851093 this was previously done before we started moving things to modules but missed the cut. 

Fairly straight forward implementation except that AWS handles the config files a bit differently than the other two (which were refactored and consolidated, AWS has separate files for external services, demo mode, airgap, etc). Might be a nice fix up to do that in AWS a some point to make them match. 