### PR TITLE
Open up port 80 and have the LB forward to 443

### DIFF
--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -53,6 +53,16 @@ resource "aws_security_group" "allow_ptfe" {
   }
 
   ingress {
+    description = "http to ptfe application"
+
+    protocol  = "tcp"
+    from_port = 80
+    to_port   = 80
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     description = "https to ptfe application"
 
     protocol  = "tcp"

--- a/modules/lb/elb.tf
+++ b/modules/lb/elb.tf
@@ -37,6 +37,22 @@ resource "aws_lb_target_group" "admin" {
   }
 }
 
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = "${aws_lb.ptfe.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_lb_listener" "https" {
   load_balancer_arn = "${aws_lb.ptfe.arn}"
   port              = "443"

--- a/modules/lb/security-groups.tf
+++ b/modules/lb/security-groups.tf
@@ -40,6 +40,14 @@ resource "aws_security_group" "lb_public" {
   }
 
   ingress {
+    description = "http to ptfe application"
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     description = "https to ptfe application"
     protocol    = "tcp"
     from_port   = 443


### PR DESCRIPTION
In older versions (v4) of Terraform Enterprise nginx forward port 80 to 443 for us. But when running the new integration tests against the new version I noticed that that was no longer happening. 

To keep v5 in line with the v4 behavior this PR opens up port 80 to the load balancer and has the load balancer redirect to 443 for us. 