### PR TITLE
Updated the replicated link

### DIFF
--- a/examples/airgap/README.md
+++ b/examples/airgap/README.md
@@ -8,4 +8,4 @@ populated with the following items:
 
 * tfe-setup/ptfe.zip mirrored https://install.terraform.io/installer/ptfe.zip with ACL **public-read**. **NOTE** This file must have a public-read ACL configured so it can be downloaded directly via http.
 * tfe-setup/replicated.tar.gz mirriored from https://s3.amazonaws.com/replicated-airgap-work/replicated__docker__kubernetes.tar.gz with ACL **private**
-* tfe-setup/v201911-1.airgap with ACL **private** has been uploaded from the replicated.com portal. This contains the release we are deploying.
+* tfe-setup/v201911-1.airgap with ACL **private** has been uploaded from the replicated.com portal. This contains the release we are deploying. 

--- a/examples/airgap/README.md
+++ b/examples/airgap/README.md
@@ -7,5 +7,5 @@ This example uses a setup bucket that has been previously created and is
 populated with the following items:
 
 * tfe-setup/ptfe.zip mirrored https://install.terraform.io/installer/ptfe.zip with ACL **public-read**. **NOTE** This file must have a public-read ACL configured so it can be downloaded directly via http.
-* tfe-setup/replicated.tar.gz mirriored from https://s3.amazonaws.com/replicated-airgap-work/replicated\_\_docker\_\_kubernetes.tar.gz with ACL **private**
+* tfe-setup/replicated.tar.gz mirriored from https://s3.amazonaws.com/replicated-airgap-work/replicated__docker__kubernetes.tar.gz with ACL **private**
 * tfe-setup/v201911-1.airgap with ACL **private** has been uploaded from the replicated.com portal. This contains the release we are deploying.

--- a/examples/airgap/README.md
+++ b/examples/airgap/README.md
@@ -8,4 +8,4 @@ populated with the following items:
 
 * tfe-setup/ptfe.zip mirrored https://install.terraform.io/installer/ptfe.zip with ACL **public-read**. **NOTE** This file must have a public-read ACL configured so it can be downloaded directly via http.
 * tfe-setup/replicated.tar.gz mirriored from https://s3.amazonaws.com/replicated-airgap-work/replicated__docker__kubernetes.tar.gz with ACL **private**
-* tfe-setup/v201911-1.airgap with ACL **private** has been uploaded from the replicated.com portal. This contains the release we are deploying. 
+* tfe-setup/v201911-1.airgap with ACL **private** has been uploaded from the replicated.com portal. This contains the release we are deploying.


### PR DESCRIPTION
Note: When you view the link on github  it doesn't work. It renders as (https://s3.amazonaws.com/replicated-airgap-work/replicated%5C_%5C_docker%5C_%5C_kubernetes.tar.gz)
When you view the link via the module (https://registry.terraform.io/modules/hashicorp/terraform-enterprise/aws/0.1.1/examples/airgap) it does.
I am trying to resolve that with this change