### PR TITLE
Fix mixing SG in-line rules with rule resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# Local .terraform directories
+**/.terraform/*
+
 work/

--- a/config.tf
+++ b/config.tf
@@ -1,6 +1,6 @@
 locals {
   app_data_mode    = "${var.postgresql_address != "" ? "external_services" : "demo"}"
-  app_network_type = "${var.airgap_package_url != "" ? "airgap" : "online" }"
+  app_network_type = "${var.airgap_package_url != "" ? "airgap" : "online"}"
   install_type     = "${local.app_data_mode}-${local.app_network_type}"
 }
 

--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "intra_vpc_and_egress" {
 }
 
 resource "aws_security_group_rule" "intra_vpc_and_egress_ingress_rule" {
-  security_group_id = aws_security_group.intra_vpc_and_egress.id
+  security_group_id = "${aws_security_group.intra_vpc_and_egress.id}"
 
   type = "ingress"
 
@@ -23,7 +23,7 @@ resource "aws_security_group_rule" "intra_vpc_and_egress_ingress_rule" {
 }
 
 resource "aws_security_group_rule" "intra_vpc_and_egress_egress_rule" {
-  security_group_id = aws_security_group.intra_vpc_and_egress.id
+  security_group_id = "${aws_security_group.intra_vpc_and_egress.id}"
 
   type        = "egress"
   description = "outbound access to the world"
@@ -31,6 +31,7 @@ resource "aws_security_group_rule" "intra_vpc_and_egress_egress_rule" {
   protocol  = "-1"
   from_port = 0
   to_port   = 0
+
   cidr_blocks = [
     "0.0.0.0/0",
   ]

--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -2,27 +2,38 @@ resource "aws_security_group" "intra_vpc_and_egress" {
   description = "allow instances to talk to each other, and have unfettered egress"
   vpc_id      = "${var.vpc_id}"
 
-  ingress {
-    protocol  = "-1"
-    from_port = 0
-    to_port   = 0
-
-    self = true
-  }
-
-  egress {
-    description = "outbound access to the world"
-
-    protocol  = "-1"
-    from_port = 0
-    to_port   = 0
-
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # NOTE: you cannot (should not) mix in-line ingress/egress rules with the
+  # aws_security_group_rule resource
+  # https://www.terraform.io/docs/providers/aws/r/security_group_rule.html
 
   tags = {
     Name = "${var.prefix}"
   }
+}
+
+resource "aws_security_group_rule" "intra_vpc_and_egress_ingress_rule" {
+  security_group_id = aws_security_group.intra_vpc_and_egress.id
+
+  type = "ingress"
+
+  protocol  = "-1"
+  from_port = 0
+  to_port   = 0
+  self      = true
+}
+
+resource "aws_security_group_rule" "intra_vpc_and_egress_egress_rule" {
+  security_group_id = aws_security_group.intra_vpc_and_egress.id
+
+  type        = "egress"
+  description = "outbound access to the world"
+
+  protocol  = "-1"
+  from_port = 0
+  to_port   = 0
+  cidr_blocks = [
+    "0.0.0.0/0",
+  ]
 }
 
 # Allow whitelisted ranges to access our services.

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 locals {
   assistant_port                   = 23010
-  distro_ami                       = "${var.distribution== "ubuntu" ? data.aws_ami.ubuntu.id  : data.aws_ami.rhel.id}"
-  default_ssh_user                 = "${var.distribution== "ubuntu" ? "ubuntu" : "ec2-user"}"
+  distro_ami                       = "${var.distribution == "ubuntu" ? data.aws_ami.ubuntu.id : data.aws_ami.rhel.id}"
+  default_ssh_user                 = "${var.distribution == "ubuntu" ? "ubuntu" : "ec2-user"}"
   rendered_secondary_instance_type = "${var.secondary_instance_type != "" ? var.secondary_instance_type : var.primary_instance_type}"
 }
 


### PR DESCRIPTION
* Security Group in-line ingress/egress rules cannot (should not) be mixed with the `aws_security_group_rule` resource. This is a documented incompatibility that results in rule overwrites.
    * https://www.terraform.io/docs/providers/aws/r/security_group_rule.html

* Update .gitignore to include '.terraform' directories
* Run `terraform fmt` against all files