### PR TITLE
Readd egress

### DIFF
--- a/module-common.tf
+++ b/module-common.tf
@@ -2,7 +2,7 @@ module "common" {
   source             = "./modules/common-user-vpc"
   vpc_id             = var.vpc_id
   subnet_tags        = var.subnet_tags
-  ingress_allow_list = var.allow_list
+  ingress_allow_list = var.ingress_allow_list
   prefix             = var.prefix
 }
 

--- a/module-common.tf
+++ b/module-common.tf
@@ -1,8 +1,8 @@
 module "common" {
-  source      = "./modules/common-user-vpc"
-  vpc_id      = var.vpc_id
-  subnet_tags = var.subnet_tags
-  allow_list  = var.allow_list
-  prefix      = var.prefix
+  source             = "./modules/common-user-vpc"
+  vpc_id             = var.vpc_id
+  subnet_tags        = var.subnet_tags
+  ingress_allow_list = var.allow_list
+  prefix             = var.prefix
 }
 

--- a/modules/common-user-vpc/outputs.tf
+++ b/modules/common-user-vpc/outputs.tf
@@ -42,8 +42,8 @@ output "public_subnets_cidr_blocks" {
   value = matchkeys(values(data.aws_subnet.selected)[*].cidr_block, values(data.aws_subnet.selected)[*].map_public_ip_on_launch, list("true"))
 }
 
-output "intra_vpc_and_egress_sg_id" {
-  value = aws_security_group.intra_vpc_and_egress.id
+output "intra_vpc_ingress_and_egress_sg_id" {
+  value = aws_security_group.intra_vpc_ingress_and_egress.id
 }
 
 output "allow_ptfe_sg_id" {

--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "intra_vpc_ingress_and_egress" {
   description = "allow instances to talk to each other, and set up trusted ingress and egress"
   vpc_id      = var.vpc_id
+  name        = "${prefix}-intra-cluster-and-trusted-blocks"
 
   ingress {
     protocol  = "-1"

--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -1,37 +1,34 @@
-resource "aws_security_group" "intra_vpc_and_egress" {
-  description = "allow instances to talk to each other, and have unfettered egress"
+resource "aws_security_group" "intra_vpc_ingress_and_egress" {
+  description = "allow instances to talk to each other, and set up trusted ingress and egress"
   vpc_id      = var.vpc_id
 
-  # NOTE: you cannot (should not) mix in-line ingress/egress rules with the
-  # aws_security_group_rule resource
-  # https://www.terraform.io/docs/providers/aws/r/security_group_rule.html
+  ingress {
+    protocol  = "-1"
+    from_port = 0
+    to_port   = 0
+    self      = true
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = var.egress_allow_list
+  }
+
+  dynamic "ingress" {
+    for_each = var.ingress_allow_list
+    content {
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      cidr_blocks = ingress.value
+    }
+  }
 
   tags = {
     Name = "${var.prefix}"
   }
-}
-
-resource "aws_security_group_rule" "intra_vpc_and_egress_ingress_rule" {
-  security_group_id = "${aws_security_group.intra_vpc_and_egress.id}"
-
-  type = "ingress"
-
-  protocol  = "-1"
-  from_port = 0
-  to_port   = 0
-  self      = true
-}
-
-# Allow whitelisted ranges to access our services.
-# For example, an HTTP proxy.
-resource "aws_security_group_rule" "allow_list" {
-  count             = length(var.allow_list) > 0 ? 1 : 0
-  type              = "ingress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = var.allow_list
-  security_group_id = aws_security_group.intra_vpc_and_egress.id
 }
 
 resource "aws_security_group" "allow_ptfe" {

--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "intra_vpc_ingress_and_egress" {
   description = "allow instances to talk to each other, and set up trusted ingress and egress"
   vpc_id      = var.vpc_id
-  name        = "${prefix}-intra-cluster-and-trusted-blocks"
+  name        = "${var.prefix}-intra-cluster-and-trusted-blocks"
 
   ingress {
     protocol  = "-1"

--- a/modules/common-user-vpc/variables.tf
+++ b/modules/common-user-vpc/variables.tf
@@ -18,11 +18,18 @@ variable "subnet_tags" {
   default     = {}
 }
 
-variable "allow_list" {
+variable "ingress_allow_list" {
   type        = "list"
-  description = "list of CIDRs we allow to access the infrastructure"
+  description = "list of CIDR blocks we allow to access the infrastructure"
   default     = []
 }
+
+variable "egress_allow_list" {
+  type        = "list"
+  description = "List of CIDR blocks we allow the infrastructure to access"
+  default     = ["0.0.0.0/0"]
+}
+
 
 ### ======================================================================= MISC
 

--- a/primary.tf
+++ b/primary.tf
@@ -12,7 +12,7 @@ resource "aws_instance" "primary" {
 
   vpc_security_group_ids = [
     module.lb.sg_lb_to_instance,
-    module.common.intra_vpc_and_egress_sg_id,
+    module.common.intra_vpc_ingress_and_egress_sg_id,
     module.common.allow_ptfe_sg_id,
   ]
 

--- a/primary_lb.tf
+++ b/primary_lb.tf
@@ -7,7 +7,7 @@ resource "aws_elb" "cluster_api" {
 
   cross_zone_load_balancing = true
 
-  security_groups = [module.common.intra_vpc_and_egress_sg_id]
+  security_groups = [module.common.intra_vpc_ingress_and_egress_sg_id]
 
   idle_timeout = 3600 # for kubectl commands
 

--- a/secondary.tf
+++ b/secondary.tf
@@ -8,7 +8,7 @@ resource "aws_launch_configuration" "secondary" {
 
   security_groups = [
     module.lb.sg_lb_to_instance,
-    module.common.intra_vpc_and_egress_sg_id,
+    module.common.intra_vpc_ingress_and_egress_sg_id,
     module.common.allow_ptfe_sg_id,
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -242,11 +242,18 @@ variable "s3_region" {
   default     = ""
 }
 
-variable "allow_list" {
+variable "ingress_allow_list" {
   type        = list(string)
-  description = "List of CIDRs we allow to access the infrastructure"
+  description = "List of CIDR blocks we allow to access the infrastructure"
   default     = []
 }
+
+variable "egress_allow_list" {
+  type        = list(string)
+  description = "List of CIDR blocks we allow the infrastructyre to access"
+  default     = ["0.0.0.0/0"]
+}
+
 
 ### ======================================================================= MISC
 


### PR DESCRIPTION
## Background

Somewhere in the migration to 0.12 configs, we lost egress, this PR adds back egress, but in a more flexible way.

Closes #50 

**This change breaks the variable contract for the root module as well as the common-user-vpc submodule**


## How Has This Been Tested

Cluster was successfully spun up with the following configs

```hcl
provider "aws" {
  region = "us-west-2"
}

module "tfe" {
  source       = "git@github.com:hashicorp/terraform-aws-terraform-enterprise?ref=ea/b-readd-egress"
  license_file = "./stable-ha.rli"
  vpc_id       = "vpc-0123456789abcde" 
  domain       = "test.domain"

  subnet_tags = {
    Application = "test application"
  }
}

output "tfe" {
  value = {
    installer_dashboard_password = "${module.tfe.installer_dashboard_password}"
    installer_dashboard_url      = "${module.tfe.installer_dashboard_url}"
    install_id                   = "${module.tfe.install_id}"
  }
}

```
### Test Configuration

* Terraform Version: 0.12.13
* Any additional relevant variables: none

## This PR makes me feel

![Finn the Human in front of the door of the Hall of Egress](https://y.yarn.co/54f92983-0735-414f-8b0a-b1eae36aeab3_screenshot.jpg)
