### PR TITLE
Add GovCloud AWS account IDs for RedHat and Canonical to variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -258,7 +258,7 @@ variable "egress_allow_list" {
 ### ======================================================================= MISC
 
 data "aws_ami" "ubuntu" {
-  owners = ["099720109477"] # Canonical
+  owners = ["099720109477", "513442679011"] # Canonical, Canonical (GovCloud)
 
   most_recent = true
 
@@ -274,7 +274,7 @@ data "aws_ami" "ubuntu" {
 }
 
 data "aws_ami" "rhel" {
-  owners = ["309956199498"] # RedHat
+  owners = ["309956199498", "219670896067"] # RedHat, RedHat (GovCloud)
 
   most_recent = true
 


### PR DESCRIPTION
## Background

Adding the AWS account IDs for Red Hat and Canonical in the GovCloud region allows this module to be used to deploy TFE in GovCloud (assuming that you also set `update_route53 = false`, given that GovCloud Route53 does not have public hosted zones). Without this change, attempting to look up a Red Hat/Ubuntu AMI fails because the existing account IDs do not exist in GovCloud.

## How Has This Been Tested

I've tested these changes by using this module to deploy TFE in us-gov-west-1.

You can verify the AWS Account IDs are valid with the following links:
- Red Hat: It is published [here](https://access.redhat.com/solutions/15356).
- Canoncial: It isn't published anywhere that I could find, but you can find a GovCloud region AMI ID [here](https://cloud-images.ubuntu.com/locator/ec2/) (for example, `ami-cc7e21ad`) and use the AWS CLI to find the owner's account ID.

```
aws ec2 describe-images --image-ids ami-cc7e21ad --region us-gov-west-1
```

### Test Configuration

* Terraform Version: 0.12
* Any additional relevant variables: Deploying into GovCloud requires that `update_route53 = false` is set (because public hosted zones do not exist in GovCloud Route53).

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/YoB1eEFB6FZ1m/giphy.gif)
