### PR TITLE
Include install id in security group name to prevent collisions

### DIFF
--- a/modules/common-user-vpc/security_groups.tf
+++ b/modules/common-user-vpc/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "intra_vpc_ingress_and_egress" {
   description = "allow instances to talk to each other, and set up trusted ingress and egress"
   vpc_id      = var.vpc_id
-  name        = "${var.prefix}-intra-cluster-and-trusted-blocks"
+  name        = "${var.prefix}-${random_string.install_id.result}-intra-cluster-and-trusted-blocks"
 
   ingress {
     protocol  = "-1"


### PR DESCRIPTION
## Background

https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/51/ fixed a problem we had where we no longer had egress on our machines but the name used for the security group didn't include the install ID. For most installs this won't be a problem but for CI/development and for installs where there are multiple clusters installed to the same VPC there can be collisions on this name. 

This PR adds the `install_id` to the name to prevent collisions. 

## How Has This Been Tested

Ran into this locally in our development account. Made this change and re-ran the plan/apply and the problem went away. 

## This PR makes me feel

![two spidermen pointing at each other](https://media.giphy.com/media/l36kU80xPf0ojG0Erg/giphy.gif)
