### PR TITLE
Private subnet deployment

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -5,6 +5,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | domain | Route53 Domain to manage DNS under | string | n/a | yes |
+| private\_zone | set to true if your route53 zone is private | string | false | no |
 | license\_file | path to license file | string | n/a | yes |
 | vpc\_id | AWS VPC id to install into | string | n/a | yes |
 | airgap\_installer\_url | URL to airgap installer package | string | `"https://s3.amazonaws.com/replicated-airgap-work/replicated__docker__kubernetes.tar.gz"` | no |

--- a/module-lb.tf
+++ b/module-lb.tf
@@ -4,8 +4,8 @@ module "lb" {
   vpc_id     = module.common.vpc_id
   install_id = module.common.install_id
 
-  prefix = var.prefix
-  domain = var.domain
+  prefix       = var.prefix
+  domain       = var.domain
   private_zone = var.private_zone
 
   public_subnets              = module.common.public_subnets

--- a/module-lb.tf
+++ b/module-lb.tf
@@ -6,8 +6,10 @@ module "lb" {
 
   prefix = var.prefix
   domain = var.domain
+  private_zone = var.private_zone
 
   public_subnets              = module.common.public_subnets
+  private_subnets             = module.common.private_subnets
   public_subnets_cidr_blocks  = module.common.public_subnets_cidr_blocks
   private_subnets_cidr_blocks = module.common.private_subnets_cidr_blocks
 

--- a/modules/lb/elb.tf
+++ b/modules/lb/elb.tf
@@ -1,6 +1,7 @@
 resource "aws_lb" "ptfe" {
-  subnets            = var.public_subnets
+  subnets            = var.private_zone ? var.private_subnets : var.public_subnets
   load_balancer_type = "application"
+  internal           = var.private_zone
 
   security_groups = [
     aws_security_group.lb_public.id,

--- a/modules/lb/variables.tf
+++ b/modules/lb/variables.tf
@@ -15,6 +15,11 @@ variable "public_subnets" {
   description = "list of public subnets"
 }
 
+variable "private_subnets" {
+  type        = "list"
+  description = "list of private subnets"
+}
+
 variable "public_subnets_cidr_blocks" {
   type        = "list"
   description = "list of CIDRs for the public subnets"
@@ -29,6 +34,12 @@ variable "private_subnets_cidr_blocks" {
 variable "domain" {
   type        = "string"
   description = "this is used to find an existing issued wildcard cert and route53 zone"
+}
+
+variable "private_zone" {
+  type        = "string"
+  description = "set to true if your route53 zone is private"
+  default     = false
 }
 
 variable "hostname" {
@@ -75,6 +86,7 @@ data "aws_acm_certificate" "lb" {
 data "aws_route53_zone" "zone" {
   count = var.update_route53 ? 1 : 0
   name  = var.domain
+  private_zone = var.private_zone
 }
 
 locals {

--- a/primary.tf
+++ b/primary.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "primary" {
   ami           = var.ami != "" ? var.ami : local.distro_ami
   instance_type = var.primary_instance_type
 
-  subnet_id = element(module.common.public_subnets, count.index)
+  subnet_id = element(var.private_zone ? module.common.private_subnets : module.common.public_subnets, count.index)
 
   vpc_security_group_ids = [
     module.lb.sg_lb_to_instance,

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "domain" {
   description = "Route53 Domain to manage DNS under"
 }
 
+variable "private_zone" {
+  type        = "string"
+  description = "set to true if your route53 zone is private"
+  default     = false
+}
+
 variable "license_file" {
   type        = string
   description = "path to license file"


### PR DESCRIPTION
## Background

Add a new input variable private_zone to force use of a private route53 domain.
This will also deploy the ptfe lb and primary instances into private subnets.


Relates #49


## How Has This Been Tested

Planned and applied into private subnets. 
private_zone set to true
domain set to a private route53 domain

### Test Configuration

* Terraform Version: v0.12.19
* Any additional relevant variables: n/a

## This PR makes me feel

![Classified](https://media.giphy.com/media/aWxbEGCqkiZFK/giphy.gif)
