### PR TITLE
Add output for load balancer DNS name

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -10,6 +10,7 @@
 | install\_id |  |
 | installer\_dashboard\_password |  |
 | installer\_dashboard\_url |  |
+| load\_balancer\_dns\_name |  |
 | primary\_public\_ip |  |
 | ssh\_config\_file |  |
 | ssh\_private\_key |  |

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,10 @@ output "primary_public_ip" {
   value = element(aws_instance.primary.*.public_ip, 0)
 }
 
+output "load_balancer_dns_name" {
+	value = module.lb.lb_endpoint
+}
+
 output "ssh_config_file" {
   value = local_file.ssh_config.filename
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,7 +33,7 @@ output "primary_public_ip" {
 }
 
 output "load_balancer_dns_name" {
-	value = module.lb.lb_endpoint
+  value = module.lb.lb_endpoint
 }
 
 output "ssh_config_file" {


### PR DESCRIPTION
## Background

Add a new output load_balancer_dns_name to allow creation of a route53 CNAME record as a separate Terraform resource outside of the module which points directly to the application load balancer. This is useful for cases such as when the desired route53 public hosted zone exists in a separate AWS account.

## How Has This Been Tested

Applied to ensure that the output is populated.

### Test Configuration

* Terraform Version: 0.12.20
* Any additional relevant variables: N/A

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/IcGkqdUmYLFGE/giphy.gif)
