### PR TITLE
Don't overwrite /etc/sysconfig/selinux symlink

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -33,7 +33,7 @@ if [ -f /etc/redhat-release ]; then
   setenforce 0
   mkdir -p /lib/tc
   mount --bind /usr/lib64/tc/ /lib/tc/
-  sed -i -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
+  sed -i ---follow-symlinks -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
   sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
   yum -y install docker wget jq chrony ipvsadm unzip
   systemctl enable docker

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -33,7 +33,7 @@ if [ -f /etc/redhat-release ]; then
   setenforce 0
   mkdir -p /lib/tc
   mount --bind /usr/lib64/tc/ /lib/tc/
-  sed -i ---follow-symlinks -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
+  sed -i --follow-symlinks -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
   sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
   yum -y install docker wget jq chrony ipvsadm unzip
   systemctl enable docker


### PR DESCRIPTION
## Background

This is the AWS implementation of https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/75 which went as stated: 

> The `install-ptfe.sh` script on RHEL tries to modify `/etc/sysconfig/selinux` in place using `sed` in order to disable SELinux. Since that file is a symlink to `/etc/selinux/config` on modern versions of RHEL, `sed` needs the `--follow-symlinks` option or it will overwrite the file and remove the symlink. This could cause undesirable results including not actually disabling SELinux across reboots as intended.


## How Has This Been Tested

Successfully spun up a 7.7 RHEL Cluster and confirmed the symlink was still a symlink

### Test Configuration

* Terraform Version: 0.12.18

## This PR makes me feel

![HYPNOTOAD ASKS YOU POLITELY TO FOLLOW](https://media.giphy.com/media/11EIJWejKzCnM4/giphy.gif)
