### PR TITLE
Parametrize the RDS instance class in the external services module

### DIFF
--- a/modules/external-services/main.tf
+++ b/modules/external-services/main.tf
@@ -18,6 +18,12 @@ variable "prefix" {
   default     = ""
 }
 
+variable "rds_instance_class" {
+  type        = string
+  description = "instance class of the database"
+  default     = "db.r5.large"
+}
+
 variable "rds_subnet_tags" {
   type        = map
   description = "tags to use to match subnets to use"

--- a/modules/external-services/rds.tf
+++ b/modules/external-services/rds.tf
@@ -61,6 +61,6 @@ resource "aws_rds_cluster_instance" "tfe1" {
   cluster_identifier   = aws_rds_cluster.tfe.id
   identifier_prefix    = "${var.prefix}tfe1"
   engine               = "aurora-postgresql"
-  instance_class       = "db.r5.large"
+  instance_class       = var.rds_instance_class
   db_subnet_group_name = aws_db_subnet_group.tfe.name
 }


### PR DESCRIPTION
## Background

This was done because the hardcoded RDS instance class value of "db.r5.large" in the external services module isn't currently available in GovCloud. This change will allow users to specify their own instance class (for example, "db.r4.large" for those users that are
in GovCloud).

## How Has This Been Tested

I've successfully deployed this in our own GovCloud environment by utilizing this new variable:

```
module "external" {
  source  = ...
  vpc_id = local.vpc_id
  install_id = module.terraform-enterprise.install_id
  rds_instance_class = "db.r4.large"
}
```

### Test Configuration

* Terraform Version: v0.12.x
