### PR TITLE
Allow the use of EC2 instance profile for S3 authentication

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -18,6 +18,7 @@ data "template_file" "repl_ptfe_config" {
     pg_netloc              = var.postgresql_address
     pg_dbname              = var.postgresql_database
     pg_extra_params        = var.postgresql_extra_params
+    aws_instance_profile   = var.aws_instance_profile ? "1" : "0"
     aws_access_key_id      = var.aws_access_key_id
     aws_secret_access_key  = var.aws_secret_access_key
     s3_bucket_name         = var.s3_bucket

--- a/data/es.json
+++ b/data/es.json
@@ -23,6 +23,9 @@
     "pg_extra_params": {
         "value": "${pg_extra_params}"
     },
+    "aws_instance_profile": {
+        "value": "${aws_instance_profile}"
+    },
     "aws_access_key_id": {
         "value": "${aws_access_key_id}"
     },

--- a/data/es_airgap.json
+++ b/data/es_airgap.json
@@ -23,6 +23,9 @@
     "pg_extra_params": {
         "value": "${pg_extra_params}"
     },
+    "aws_instance_profile": {
+        "value": "${aws_instance_profile}"
+    },
     "aws_access_key_id": {
         "value": "${aws_access_key_id}"
     },

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,12 @@ variable "repl_cidr" {
 
 ### ================================ External Services Support
 
+variable "aws_instance_profile" {
+  type        = string
+  description = "When set, use credentials from the AWS instance profile"
+  default     = false
+}
+
 variable "aws_access_key_id" {
   type        = string
   description = "AWS access key id to connect to s3 with"

--- a/variables.tf
+++ b/variables.tf
@@ -189,7 +189,7 @@ variable "repl_cidr" {
 ### ================================ External Services Support
 
 variable "aws_instance_profile" {
-  type        = string
+  type        = bool
   description = "When set, use credentials from the AWS instance profile"
   default     = false
 }


### PR DESCRIPTION
## Background

Optionally allows users to specify `aws_instance_profile = true` and configure their cluster to use the EC2 metadata API to obtain S3 credentials. 


## How Has This Been Tested

I launched a cluster with this branch and verified that the Replicated console showed the option set. When the instance role is configured appropriately, the "Test Authentication" button works. Because `iam_role` is already an output, I was able to use [`aws_iam_role_policy_attachment`](https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html) to modify its permissions.

<img width="820" alt="Screen Shot 2020-02-28 at 17 24 59" src="https://user-images.githubusercontent.com/808808/75710353-4b290880-5c79-11ea-9488-92503efef235.png">

I did observe that the auth test seems to require more permissions than the `external-services` module grants. I needed to add the following to my policy document:

```hcl
statement {
  actions = [
    "s3:ListAllMyBuckets",
  ]

  resources = ["*"]
}
```

### Test Configuration

* Terraform Version: 0.12.20

## This PR makes me feel

![ec2 metadata api be like](https://media.giphy.com/media/3o6MbahQY8y8Ek8uze/source.gif)
