### PR TITLE
Fix RHEL Script to install Docker

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -35,6 +35,7 @@ if [ -f /etc/redhat-release ]; then
   mount --bind /usr/lib64/tc/ /lib/tc/
   sed -i --follow-symlinks -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
   sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
+  sed -i -e '/rhui-rhel-7-server-rhui-extras-rpms/,/^$/s/enabled=0/enabled=1/g' /etc/yum.repos.d/redhat-rhui.repo
   yum -y install docker wget jq chrony ipvsadm unzip
   systemctl enable docker
   systemctl start docker


### PR DESCRIPTION
The RHEL AMI from the AWS marketplace has a different string that's in the script:

From a brand new RHEL 7 image (Created 4th March 2020):

```
[root@ip-172-31-9-155 ec2-user]# cat /etc/yum.repos.d/redhat-rhui.repo | grep 'extras-rpms' -A 5
[rhui-rhel-7-server-rhui-extras-rpms]
name=Red Hat Enterprise Linux 7 Server - Extras from RHUI (RPMs)
mirrorlist=https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel/rhui/server/7/7Server/$basearch/extras/os
enabled=1
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
```

Note that it's `rhui-rhel-7-server-rhui-extras-rpms` not `rhui-REGION-rhel-server-extras`

## How Has This Been Tested

> Before (using current script)

```
[root@ip-172-31-9-155 ec2-user]# sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g' /etc/yum.repos.d/redhat-rhui.repo
[root@ip-172-31-9-155 ec2-user]# yum install docker
Loaded plugins: amazon-id, search-disabled-repos
rhui-client-config-server-7                                                                                                                                                                                                            | 2.1 kB  00:00:00
rhui-rhel-7-server-rhui-rh-common-rpms                                                                                                                                                                                                 | 2.1 kB  00:00:00
rhui-rhel-7-server-rhui-rpms                                                                                                                                                                                                           | 2.0 kB  00:00:00
(1/9): rhui-client-config-server-7/x86_64/updateinfo                                                                                                                                                                                   |   92 B  00:00:00
(2/9): rhui-client-config-server-7/x86_64/group                                                                                                                                                                                        |  124 B  00:00:00
(3/9): rhui-client-config-server-7/x86_64/primary                                                                                                                                                                                      | 1.5 kB  00:00:00
(4/9): rhui-rhel-7-server-rhui-rh-common-rpms/7Server/x86_64/updateinfo                                                                                                                                                                |  35 kB  00:00:00
(5/9): rhui-rhel-7-server-rhui-rh-common-rpms/7Server/x86_64/group                                                                                                                                                                     |  124 B  00:00:00
(6/9): rhui-rhel-7-server-rhui-rh-common-rpms/7Server/x86_64/primary                                                                                                                                                                   |  68 kB  00:00:00
(7/9): rhui-rhel-7-server-rhui-rpms/7Server/x86_64/group                                                                                                                                                                               | 772 kB  00:00:00
(8/9): rhui-rhel-7-server-rhui-rpms/7Server/x86_64/updateinfo                                                                                                                                                                          | 3.6 MB  00:00:00
(9/9): rhui-rhel-7-server-rhui-rpms/7Server/x86_64/primary                                                                                                                                                                             |  42 MB  00:00:00
rhui-client-config-server-7                                                                                                                                                                                                                               5/5
rhui-rhel-7-server-rhui-rh-common-rpms                                                                                                                                                                                                                242/242
rhui-rhel-7-server-rhui-rpms                                                                                                                                                                                                                      27012/27012
No package docker available.
Error: Nothing to do
```

> After (using this change) 

```
[root@ip-172-31-9-155 ec2-user]# sed -i -e '/rhui-rhel-7-server-rhui-extras-rpms/,/^$/s/enabled=0/enabled=1/g' /etc/yum.repos.d/redhat-rhui.repo
[root@ip-172-31-9-155 ec2-user]# yum install docker
Loaded plugins: amazon-id, search-disabled-repos
rhui-rhel-7-server-rhui-extras-rpms                                                                                                                                                                                                    | 2.0 kB  00:00:00
rhui-rhel-7-server-rhui-rh-common-rpms                                                                                                                                                                                                 | 2.1 kB  00:00:00
rhui-rhel-7-server-rhui-rpms                                                                                                                                                                                                           | 2.0 kB  00:00:00
(1/3): rhui-rhel-7-server-rhui-extras-rpms/x86_64/group                                                                                                                                                                                |  124 B  00:00:00
(2/3): rhui-rhel-7-server-rhui-extras-rpms/x86_64/updateinfo                                                                                                                                                                           | 221 kB  00:00:00
(3/3): rhui-rhel-7-server-rhui-extras-rpms/x86_64/primary                                                                                                                                                                              | 370 kB  00:00:00
rhui-rhel-7-server-rhui-extras-rpms                                                                                                                                                                                                                 1229/1229
Resolving Dependencies
--> Running transaction check
---> Package docker.x86_64 2:1.13.1-109.gitcccb291.el7_7 will be installed
--> Processing Dependency: docker-common = 2:1.13.1-109.gitcccb291.el7_7 for package: 2:docker-1.13.1-109.gitcccb291.el7_7.x86_64
--> Processing Dependency: docker-client = 2:1.13.1-109.gitcccb291.el7_7 for package: 2:docker-1.13.1-109.gitcccb291.el7_7.x86_64
--> Running transaction check
```

### Test Configuration

N/A

## This PR makes me feel

![https://media.giphy.com/media/47HLJw2Cd7TVnTwrS9/giphy.gif](https://media.giphy.com/media/47HLJw2Cd7TVnTwrS9/giphy.gif)