### PR TITLE
Local primary count

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -43,7 +43,7 @@ locals {
 }
 
 data "template_file" "cloud_config" {
-  count    = var.primary_count
+  count    = local.primary_count
   template = file("${path.module}/templates/cloud-config.yaml")
 
   vars = {
@@ -78,7 +78,7 @@ data "template_file" "cloud_config" {
 }
 
 data "template_cloudinit_config" "config" {
-  count         = var.primary_count
+  count         = local.primary_count
   gzip          = true
   base64_encode = true
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -33,7 +33,6 @@
 | postgresql\_password | password to connect to external postgresql database as | `string` | `""` | no |
 | postgresql\_user | user to connect to external postgresql database as | `string` | `""` | no |
 | prefix | Name prefix for resource names and tags | `string` | `"tfe"` | no |
-| primary\_count | The number of primary cluster master nodes to run, only 3 support now. | `string` | `3` | no |
 | primary\_instance\_type | ec2 instance type | `string` | `"m4.xlarge"` | no |
 | private\_zone | set to true if your route53 zone is private | `string` | `false` | no |
 | release\_sequence | Replicated release sequence number to install - this locks the install to a specific release | `string` | `""` | no |

--- a/examples/airgap/main.tf
+++ b/examples/airgap/main.tf
@@ -68,7 +68,6 @@ module "terraform-enterprise" {
   }
 
   license_file    = local.license_file
-  primary_count   = 3
   secondary_count = 5
   hostname        = local.hostname
   distribution    = "ubuntu"

--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -34,7 +34,6 @@ You'll need to update the following settings to your set up:
 	* domain: The domain setup in Route53
 	* license_file: License file provided by your TAM or SE
 	* secondary_count: Number of worker instances to create
-	* primary_count: Number of primaries to create
 	* distribution: OS Distribution to use - ubuntu or rhel
 
  This example is set to spin up 3 primaries and 3 secondaries.

--- a/primary.tf
+++ b/primary.tf
@@ -40,37 +40,37 @@ resource "aws_instance" "primary" {
 }
 
 resource "aws_elb_attachment" "ptfe_app-primary" {
-  count    = var.primary_count
+  count    = local.primary_count
   elb      = aws_elb.cluster_api.id
   instance = element(aws_instance.primary.*.id, count.index)
 }
 
 resource "aws_elb_attachment" "ptfe_admin-primary" {
-  count    = var.primary_count
+  count    = local.primary_count
   elb      = aws_elb.cluster_api.id
   instance = element(aws_instance.primary.*.id, count.index)
 }
 
 resource "aws_elb_attachment" "cluster_api-primary" {
-  count    = var.primary_count
+  count    = local.primary_count
   elb      = aws_elb.cluster_api.id
   instance = element(aws_instance.primary.*.id, count.index)
 }
 
 resource "aws_elb_attachment" "cluster_assistant-primary" {
-  count    = var.primary_count
+  count    = local.primary_count
   elb      = aws_elb.cluster_api.id
   instance = element(aws_instance.primary.*.id, count.index)
 }
 
 resource "aws_lb_target_group_attachment" "admin-primary" {
-  count            = var.primary_count
+  count            = local.primary_count
   target_group_arn = module.lb.admin_group
   target_id        = aws_instance.primary[count.index].id
 }
 
 resource "aws_lb_target_group_attachment" "https-primary" {
-  count            = var.primary_count
+  count            = local.primary_count
   target_group_arn = module.lb.https_group
   target_id        = aws_instance.primary[count.index].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@ locals {
   assistant_port                   = 23010
   distro_ami                       = var.distribution == "ubuntu" ? data.aws_ami.ubuntu.id : data.aws_ami.rhel.id
   default_ssh_user                 = var.distribution == "ubuntu" ? "ubuntu" : "ec2-user"
+  primary_count                   = 3  # The number of primary cluster master nodes to run, only 3 support now.
   rendered_secondary_instance_type = var.secondary_instance_type != "" ? var.secondary_instance_type : var.primary_instance_type
 }
 
@@ -112,12 +113,6 @@ variable "installer_url" {
   type        = string
   description = "URL to the cluster setup tool"
   default     = "https://install.terraform.io/installer/ptfe-0.1.zip"
-}
-
-variable "primary_count" {
-  type        = string
-  description = "The number of primary cluster master nodes to run, only 3 support now."
-  default     = 3
 }
 
 variable "primary_instance_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ locals {
   assistant_port                   = 23010
   distro_ami                       = var.distribution == "ubuntu" ? data.aws_ami.ubuntu.id : data.aws_ami.rhel.id
   default_ssh_user                 = var.distribution == "ubuntu" ? "ubuntu" : "ec2-user"
-  primary_count                   = 3  # The number of primary cluster master nodes to run, only 3 support now.
+  primary_count                    = 3 # The number of primary cluster master nodes to run, only 3 support now.
   rendered_secondary_instance_type = var.secondary_instance_type != "" ? var.secondary_instance_type : var.primary_instance_type
 }
 


### PR DESCRIPTION
## Background
`primary_count` variable currently supports only 3 nodes. Currently this attribute being omitted when supplied in module configuration. To avoid user confusion I moved it to locals.


Fixes #60 


## How Has This Been Tested

Terraform plan

### Test Configuration

* Terraform Version: v0.12.20
* Any additional relevant variables: removed `primary_count`
