### PR TITLE
Wire through additional_no_proxy to also populate the Replicated config

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -23,6 +23,7 @@ data "template_file" "repl_ptfe_config" {
     aws_secret_access_key  = var.aws_secret_access_key
     s3_bucket_name         = var.s3_bucket
     s3_bucket_region       = var.s3_region
+    additional_no_proxy    = var.additional_no_proxy
   }
 }
 

--- a/data/airgap.json
+++ b/data/airgap.json
@@ -13,5 +13,8 @@
   },
   "iact_subnet_time_limit": {
       "value": "${iact_subnet_time_limit}"
+  },
+  "extra_no_proxy": {
+    "value": "${additional_no_proxy}"
   }
 }

--- a/data/demo.json
+++ b/data/demo.json
@@ -13,5 +13,8 @@
     },
     "iact_subnet_time_limit": {
         "value": "${iact_subnet_time_limit}"
+    },
+    "extra_no_proxy": {
+        "value": "${additional_no_proxy}"
     }
 }

--- a/data/es.json
+++ b/data/es.json
@@ -46,6 +46,9 @@
     },
     "iact_subnet_time_limit": {
         "value": "${iact_subnet_time_limit}"
+    },
+    "extra_no_proxy": {
+        "value": "${additional_no_proxy}"
     }
 }
 

--- a/data/es_airgap.json
+++ b/data/es_airgap.json
@@ -46,5 +46,8 @@
     },
     "iact_subnet_time_limit": {
         "value": "${iact_subnet_time_limit}"
+    },
+    "extra_no_proxy": {
+        "value": "${additional_no_proxy}"
     }
 }


### PR DESCRIPTION
## Background

Customer ran into an issue where they noticed that the `additional_no_proxy` var was not being placed inside containers and the `extra_no_proxy` setting in our Replicated wasn't being set (leading to the first problem). 

This PR wires that on through to the appropriate configurations. 

## How Has This Been Tested

Spun up an AWS TFE Clustering cluster with a proxy and `additional_no_proxy` set. Once up, checked that `/etc/replicated-ptfe.conf` had the configuration and then shelled into the `ptfe-proxy` container to confirm that it also had it in its `no_proxy` env var. All checked out. 

## This PR makes me feel

![Grandpa Simpson Wiring Things Wrong](https://media.giphy.com/media/3orifccLknoPlLrGSc/giphy-downsized.gif)
