### PR TITLE
Update Replicated Healthcheck endpoint to hit /ping 

### DIFF
--- a/modules/lb/elb.tf
+++ b/modules/lb/elb.tf
@@ -35,7 +35,7 @@ resource "aws_lb_target_group" "admin" {
   vpc_id   = var.vpc_id
 
   health_check {
-    path     = "/"
+    path     = "/ping"
     protocol = "HTTPS"
     matcher  = "200-399"
   }


### PR DESCRIPTION
## Background

We've noticed in some cases that the Replicated logs are full of 401 and even occasionally 500s and for some customers when the instance is under load they have seen small UI outages and other blips. It turns out that hitting the `/` endpoint for the Replicated dashboard as often as we do for health checking can cause some problems in some instances. 

This PR adjusts the healthcheck endpoint for the ELB to be something more robust/meant for these sorts of checks. Talking to Replicated `/ping` was selected. 

## How Has This Been Tested

Have seen this adjustment fix some customer issues in the field. This particular PR was tested by spinning up a cluster and confirming it works as expected. 


## This PR makes me feel

![Dr Steve Brule introducing "For Your Health"](https://media.giphy.com/media/I5VqqJzSrhgFG/giphy.gif)
