### PR TITLE
Only install up to RHEL 7.7 at this time by default

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -44,6 +44,12 @@ else
   SERVICE=chrony
 fi
 
+# Some distributions (RHEL) are missing jq in some versions
+if ! command -v jq; then
+  curl -sfSL -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+  chmod +x /usr/bin/jq
+fi
+
 echo "Enabling NTP support..."
 echo "server 169.254.169.123 prefer iburst" > /tmp/chrony.conf
 cat "$CONF" >> /tmp/chrony.conf

--- a/variables.tf
+++ b/variables.tf
@@ -300,7 +300,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.?*GA*"]
+    values = ["RHEL-7.7*GA*"]
   }
 
   filter {


### PR DESCRIPTION
## Background

While doing some testing for documentation I realized my RHEL install was no longer, well, installing. Diving into it there were some snags around `jq` (as we've had in the past since there seems to be a Do they or Don't they quality to `jq` packages in various RPM/yum setups) but once getting past those I realized I ran into a bigger show stopper - this module installs the most recent RHEL in the 7 series by default and 7.8 is not yet supported by Replicated. 

We should backport this to the 0.11.x series. 

## How Has This Been Tested

Installed TFE on a RHEL setup and confirmed it worked. 

## This PR makes me feel

![Home realizes his hat has extra features](https://media.giphy.com/media/xT5LMC4dXusuVjthcI/giphy.gif)
