### PR TITLE
Conditionally look for aws_acm_certificate based on cert_domain var

### DIFF
--- a/modules/lb/elb.tf
+++ b/modules/lb/elb.tf
@@ -62,7 +62,7 @@ resource "aws_lb_listener" "https" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = var.cert_arn != "" ? var.cert_arn : data.aws_acm_certificate.lb.arn
+  certificate_arn   = var.cert_arn != "" ? var.cert_arn : data.aws_acm_certificate.lb[0].arn
 
   default_action {
     type             = "forward"
@@ -75,7 +75,7 @@ resource "aws_lb_listener" "admin" {
   port              = "8800"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = var.cert_arn != "" ? var.cert_arn : data.aws_acm_certificate.lb.arn
+  certificate_arn   = var.cert_arn != "" ? var.cert_arn : data.aws_acm_certificate.lb[0].arn
 
   default_action {
     type             = "forward"

--- a/modules/lb/variables.tf
+++ b/modules/lb/variables.tf
@@ -83,6 +83,7 @@ variable "tags" {
 
 ## issued certificate that the lb will be configured to use
 data "aws_acm_certificate" "lb" {
+  count       = var.cert_domain == "" ? 0 : 1
   domain      = var.cert_domain != "" ? var.cert_domain : "*.${var.domain}"
   statuses    = ["ISSUED"]
   most_recent = true


### PR DESCRIPTION
If the variable cert_domain is set, then don't attempt to find a data
source that corresponds to the aws_acm_certificate. This change allows
you to create the aws_acm_certificate alongside of this module in
Terraform without receiving a "No certificate for domain found in this
region" error. This change also has no effect on the other code path,
where you leave cert_domain unset and instead rely on the data source.

## Background

These changes allow for deployment in GovCloud while still automating the creation of the AWS ACM certification alongside the invocation of the module. An example of what this looks like is:

```
...

resource "aws_route53_record" "tfe_cert_validation" {
  # Point to the commercial region provider specifically when setting up the
  # Route53 record.
  provider = aws.commercial

  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
  zone_id = data.aws_route53_zone.tfe.id
  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
  ttl     = 60
}


module "terraform-enterprise" {
  ...
  cert_arn = aws_acm_certificate.cert.arn                   # The ARN for the ACM certificate to use
  ...
}

...

```

Prior to the changes in this PR, something like the above example would fail because the data source would attempt to locate the ACM certificate before it was actually created.

## How Has This Been Tested

I've used the above example to deploy a PTFE cluster in GovCloud while creating the necessary ACM certificate outside of the module and passing it in. This is necessary for me because I can't rely on the module to create Route53 record for DNS validation of the ACM certification (because this must be done in a different commercial AWS account outside of GovCloud).

### Test Configuration

* Terraform Version: 0.12
