### PR TITLE
set ssh private key permissions to 0600

### DIFF
--- a/modules/common-user-vpc/ssh-key.tf
+++ b/modules/common-user-vpc/ssh-key.tf
@@ -19,8 +19,9 @@ resource "aws_key_pair" "generated" {
 }
 
 resource "local_file" "private_key_pem" {
-  content  = tls_private_key.default.private_key_pem
-  filename = local.private_key_filename
+  content         = tls_private_key.default.private_key_pem
+  filename        = local.private_key_filename
+  file_permission = "0600"
 }
 
 resource "null_resource" "chmod" {


### PR DESCRIPTION
## Background

By default, Terraform sets the file permissions for local_file to 777:

https://www.terraform.io/docs/providers/local/r/file.html#file_permission

Many SSH clients raise "permissions are too open" errors and refuse to use these keys. A user can `chmod 600 $key` to resolve.

## How Has This Been Tested

Running `ssh-add` on the key after running `chmod 600` does not raise errors. I did not verify that Terraform actually sets the permissions correctly, but will trust that it does.

### Test Configuration

* Terraform Version: 0.12.24
* Any additional relevant variables: N/A

## This PR makes me feel

![](https://media.giphy.com/media/3OPTlsz4W5pkc/giphy.gif)
