### PR TITLE
Add ability to allow SSM access

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,30 @@
+data "aws_iam_policy_document" "ptfe" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "ec2.amazonaws.com",
+      ]
+    }
+  }
+}
+resource "aws_iam_role" "ptfe" {
+  name = "ptfe-${module.common.install_id}"
+
+  assume_role_policy = data.aws_iam_policy_document.ptfe.json
+}
+
+resource "aws_iam_instance_profile" "ptfe" {
+  name = "${var.prefix}-${module.common.install_id}"
+  role = aws_iam_role.ptfe.name
+}
+
+resource "aws_iam_role_policy_attachment" "ptfe_ssm" {
+  count      = var.enable_ssm_access ? 1 : 0
+  role       = aws_iam_role.ptfe.name
+  policy_arn = "${var.arn_format}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -190,6 +190,26 @@ variable "network_public_subnet_cidrs" {
   type        = list(string)
   description = "(Optional) List of public subnet CIDR ranges to create in VPC."
   default     = ["10.0.0.0/20", "10.0.16.0/20"]
+
+variable "enable_ssm_access" {
+  type        = bool
+  description = "Add an IAM policy to EC2 instances that allows AWS Session Manager access."
+  default     = false
+}
+
+variable "arn_format" {
+  type        = string
+  description = "ARN format to be used by IAM policies. May be changed to support deployment in GovCloud/China regions."
+  default     = "arn:aws"
+}
+
+
+### ================================ External Services Support
+
+variable "aws_instance_profile" {
+  type        = bool
+  description = "When set, use credentials from the AWS instance profile"
+  default     = false
 }
 
 variable "admin_dashboard_ingress_ranges" {


### PR DESCRIPTION
## Background

This PR introduces the variable `enable_ssm_access`, which when set to `true` attaches the `AmazonSSMManagedInstanceCore` IAM policy to all nodes in the cluster. This policy allows for managing the instances via SSM (as long as you have gone through the process of installing the SSM Agent in your AMI, for example). This variable defaults to `false`. Also added is the `arn_format` variable, which allows you to make use of this new feature the GovCloud and China regions by setting it to `arn:aws-us-gov` or `arn:aws-cn`, respectively.

## How Has This Been Tested

I have used my fork to deploy this in GovCloud.

### Test Configuration

* Terraform Version: 0.12

## This PR makes me feel

![](https://media.giphy.com/media/YjhKCgZ6ANxCKxxNoI/giphy.gif)
