### PR TITLE
Add PTFE load balancer zone ID to output

### DIFF
--- a/modules/lb/outputs.tf
+++ b/modules/lb/outputs.tf
@@ -10,6 +10,10 @@ output "lb_endpoint" {
   value = aws_lb.ptfe.dns_name
 }
 
+output "lb_zone_id" {
+  value = aws_lb.ptfe.zone_id
+}
+
 output "endpoint" {
   value = local.endpoint
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,6 +36,10 @@ output "load_balancer_dns_name" {
   value = module.lb.lb_endpoint
 }
 
+output "load_balancer_zone_id" {
+  value = module.lb.lb_zone_id
+}
+
 output "ssh_config_file" {
   value = local_file.ssh_config.filename
 }


### PR DESCRIPTION
## Background

This load balancer zone ID is useful to have as output as it is
necessary to have when creating a Route53 alias record pointing to this
load balancer. Similar things are already done for the `dns_name` of the load balancer.

## How Has This Been Tested

I have used this change to deploy a cluster in GovCloud while automating the creation of the corresponding Route53 records in a commercial region.

### Test Configuration

* Terraform Version: 0.12
* Any additional relevant variables:

## This PR makes me feel

![](https://media.giphy.com/media/G5QWbk1jZoCLm/giphy.gif)
