### PR TITLE
Don't fail on ptfe tool install when re-running `install-ptfe.sh`

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -50,12 +50,14 @@ cat "$CONF" >> /tmp/chrony.conf
 cp /tmp/chrony.conf "$CONF"
 systemctl restart $SERVICE
 
-pushd /tmp
-  wget -O ptfe.zip "$(cat /etc/ptfe/ptfe_url)"
-  unzip ptfe.zip
-  cp ptfe /usr/bin
-  chmod a+x /usr/bin/ptfe
-popd
+if [ ! -f /usr/bin/ptfe ]; then
+  pushd /tmp
+    wget -O ptfe.zip "$(cat /etc/ptfe/ptfe_url)"
+    unzip ptfe.zip
+    cp ptfe /usr/bin
+    chmod a+x /usr/bin/ptfe
+  popd
+fi
 
 role="$(cat /etc/ptfe/role)"
 export role


### PR DESCRIPTION
## Background

In some instances `install-ptfe.sh` fails but rerunning fails as it tries to install the `ptfe` tool again. This PR attempts to fix that portion of it allowing the install to run again which can fix issues that happened the first time around. 

## How Has This Been Tested

Tested this with an Airgap + proxy install. There may be some wrinkles with other installs that we'll need to take care of but this is the first step! 

## This PR makes me feel

![A repeating dog sees itself in the mirror](https://media.giphy.com/media/dzvcOaG7QsRd6/giphy-downsized.gif)
