### PR TITLE
Compress user data

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -50,7 +50,7 @@ data "template_file" "cloud_config" {
   vars = {
     hostname        = module.lb.endpoint
     license_b64     = filebase64(var.license_file)
-    install_ptfe_sh = filebase64("${path.module}/files/install-ptfe.sh")
+    install_ptfe_sh = base64gzip(file("${path.module}/files/install-ptfe.sh"))
     # Needed for Airgap installations
     airgap_package_url   = var.airgap_package_url
     airgap_installer_url = var.airgap_package_url == "" ? "" : count.index == 0 ? var.airgap_installer_url : local.internal_airgap_url
@@ -93,7 +93,7 @@ data "template_file" "cloud_config_secondary" {
   template = file("${path.module}/templates/cloud-config-secondary.yaml")
 
   vars = {
-    install_ptfe_sh      = filebase64("${path.module}/files/install-ptfe.sh")
+    install_ptfe_sh      = base64gzip(file("${path.module}/files/install-ptfe.sh"))
     bootstrap_token      = "${random_string.bootstrap_token_id.result}.${random_string.bootstrap_token_suffix.result}"
     cluster_api_endpoint = "${aws_elb.cluster_api.dns_name}:6443"
     health_url           = "http://${aws_elb.cluster_api.dns_name}:${local.assistant_port}/healthz"

--- a/config.tf
+++ b/config.tf
@@ -70,11 +70,11 @@ data "template_file" "cloud_config" {
     repl_cidr            = var.repl_cidr
     ca_bundle_url        = var.ca_bundle_url
     import_key           = var.import_key
-    startup_script       = base64encode(var.startup_script)
+    startup_script       = base64gzip(var.startup_script)
     role                 = count.index == 0 ? "main" : "primary"
     distro               = var.distribution
-    rptfeconf            = base64encode(data.template_file.repl_ptfe_config.rendered)
-    replconf             = base64encode(data.template_file.repl_config.rendered)
+    rptfeconf            = base64gzip(data.template_file.repl_ptfe_config.rendered)
+    replconf             = base64gzip(data.template_file.repl_config.rendered)
   }
 }
 

--- a/templates/cloud-config-secondary.yaml
+++ b/templates/cloud-config-secondary.yaml
@@ -49,7 +49,7 @@ write_files:
 - path: /var/lib/cloud/scripts/per-once/install-ptfe.sh
   owner: root:root
   permissions: "0555"
-  encoding: b64
+  encoding: gz+b64
   content: ${install_ptfe_sh}
 
 - path: /etc/ptfe/proxy-url

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -62,7 +62,7 @@ write_files:
 - path: /var/lib/cloud/scripts/per-once/000-user-startup-script.sh
   owner: root:root
   permissions: "0555"
-  encoding: b64
+  encoding: gz+b64
   content: ${startup_script}
 %{ endif }
 
@@ -119,14 +119,14 @@ write_files:
 - path: /etc/replicated-ptfe.conf
   owner: root:root
   permissions: "0644"
-  encoding: b64
+  encoding: gz+b64
   content: ${rptfeconf}
 
 ## https://help.replicated.com/docs/kb/developer-resources/automate-install/
 - path: /etc/replicated.conf
   owner: root:root
   permissions: "0644"
-  encoding: b64
+  encoding: gz+b64
   content: ${replconf}
 
 %{ if airgap_package_url != "" }

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -69,7 +69,7 @@ write_files:
 - path: /var/lib/cloud/scripts/per-once/install-ptfe.sh
   owner: root:root
   permissions: "0555"
-  encoding: b64
+  encoding: gz+b64
   content: ${install_ptfe_sh}
 
 - path: /etc/ptfe/proxy-url


### PR DESCRIPTION
## Background

With everything that is required to exist in user data as part of this module for setting up PTFE, there isn't a ton of available space for end users to add their own content to user data via the `startup_script` variable. This change applies gzip to the base64 encoded content of user data to free up some additional space for other content in user data.

## How Has This Been Tested

I've deployed my own TFE HA cluster in GovCloud successfully with these changes.

### Test Configuration

* Terraform Version: 0.12.24
