### PR TITLE
Add demo flag

### DIFF
--- a/modules/external-services/docs/inputs.md
+++ b/modules/external-services/docs/inputs.md
@@ -11,4 +11,4 @@
 | prefix | string to prefix all resources with | `string` | `""` | no |
 | rds\_instance\_class | instance class of the database | `string` | `"db.r5.large"` | no |
 | rds\_subnet\_tags | tags to use to match subnets to use | `map` | `{}` | no |
-
+| demo | Defines whether these resources are deployed as a demo | `bool` | `false` | no |

--- a/modules/external-services/main.tf
+++ b/modules/external-services/main.tf
@@ -41,3 +41,9 @@ variable "database_username" {
   description = "username of the initial user"
   default     = "tfe"
 }
+
+variable "demo" {
+  type        = bool
+  description = "Defines whether these resources are deployed as a demo"
+  default     = false
+}

--- a/modules/external-services/rds.tf
+++ b/modules/external-services/rds.tf
@@ -54,6 +54,7 @@ resource "aws_rds_cluster" "tfe" {
   preferred_backup_window   = "07:00-09:00"
   vpc_security_group_ids    = [aws_security_group.db_access.id]
   final_snapshot_identifier = "${var.prefix}tfe-${var.install_id}-final"
+  skip_final_snapshot       = var.demo == true
 }
 
 resource "aws_rds_cluster_instance" "tfe1" {


### PR DESCRIPTION
## Background

This commit adds a non-breaking change in the form of introducing a new variable `demo`, which can be used to configure the behavior of various created resources. The first use case is to avoid creating RDS snapshots when deploying as a demo.

## How Has This Been Tested

Looked at CircleCI :upside_down_face: The changes here are non-breaking, since the variable introduced includes a default value that does not change the behavior here.

## This PR makes me feel

![](https://media.giphy.com/media/czV3eLU0iAMYfIIhPW/giphy.gif)
