### PR TITLE
Allow version constraint to use all 0.Y.Z releases greater than 0.12.Z.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.12.13"
+  required_version = "~> 0.12"
 }


### PR DESCRIPTION
## Background

Shouldn't block users of Terraform CLI 0.13+ from using this module.

## How Has This Been Tested

By using this module with Terraform 0.13 and 0.14-beta.