### PR TITLE
switch to hashicorp docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   format_check:
     docker:
-      - image: "hashicorp/terraform:0.12.13"
+      - image: "docker.mirror.hashicorp.services/hashicorp/terraform:0.12.13"
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
   validation_check:
     working_directory: ~
     docker:
-      - image: "hashicorp/terraform:0.12.13"
+      - image: "docker.mirror.hashicorp.services/hashicorp/terraform:0.12.13"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR is to get around dockerhub rate limiting in CI.
