### PR TITLE
remove provider config

### DIFF
--- a/examples/personas-bank/README.md
+++ b/examples/personas-bank/README.md
@@ -37,25 +37,33 @@ not be used. Therefore when deploying, the existing VPC must have:
     values of the required variables:
 
 ```hcl
-domain_name          = "<DOMAIN_NAME>"
-license_path         = "<PATH_TO_LOCAL_LICENSE>"
-acm_certificate_arn  = "<EXISTING_ACM_CERTIFICATE_ARM>"
+provider "aws" {
+  region = "<your AWS region>"
+}
 
-# Leverages an AWS Key Pair for accessing the Bastion instance
-bastion_keypair = "<AWS_KEYPAIR_NAME>"
+module "aws_bank_persona" {
+  source = "git@github.com:hashicorp/terraform-aws-terraform-enterprise"
 
-ami_id = "<A_SUPPORTED_RHEL_AMI_ID>"
+  domain_name          = "<DOMAIN_NAME>"
+  license_path         = "<PATH_TO_LOCAL_LICENSE>"
+  acm_certificate_arn  = "<EXISTING_ACM_CERTIFICATE_ARM>"
 
-proxy_cert_bundle_filepath = "<FILE_PATH_TO_PEM>"
-proxy_cert_bundle_name     = "<NAME_OF_CERT_BUNDLE>"
-proxy_ip                   = "<IP_FOR_PROXY_AND_PORT>"
+  # Leverages an AWS Key Pair for accessing the Bastion instance
+  bastion_keypair = "<AWS_KEYPAIR_NAME>"
 
-load_balancing_scheme = "PRIVATE_TCP"
+  ami_id = "<A_SUPPORTED_RHEL_AMI_ID>"
 
-# Configure Redis security
-redis_require_password      = true
-redis_encryption_in_transit = true
-redis_encryption_at_rest    = true
+  proxy_cert_bundle_filepath = "<FILE_PATH_TO_PEM>"
+  proxy_cert_bundle_name     = "<NAME_OF_CERT_BUNDLE>"
+  proxy_ip                   = "<IP_FOR_PROXY_AND_PORT>"
+
+  load_balancing_scheme = "PRIVATE_TCP"
+
+  # Configure Redis security
+  redis_require_password      = true
+  redis_encryption_in_transit = true
+  redis_encryption_at_rest    = true
+}
 ```
 
 With the configuration created, run `terraform init` and `terraform apply` to provision the example infrastructure.

--- a/examples/personas-bank/versions.tf
+++ b/examples/personas-bank/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/examples/personas-bank/versions.tf
+++ b/examples/personas-bank/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/examples/personas-retailer/README.md
+++ b/examples/personas-retailer/README.md
@@ -37,23 +37,31 @@ not be used. Therefore when deploying, the existing VPC must have:
     values of the required variables:
 
 ```hcl
-domain_name          = "<DOMAIN_NAME>"
-license_path         = "<PATH_TO_LOCAL_LICENSE>"
-acm_certificate_arn  = "<EXISTING_ACM_CERTIFICATE_ARM>"
+provider "aws" {
+  region = "<your AWS region>"
+}
 
-# Leverages an AWS Key Pair for the accessing the Bastion instance
-bastion_keypair = "<AWS_KEYPAIR_NAME>"
+module "aws_retailer_persona" {
+  source = "git@github.com:hashicorp/terraform-aws-terraform-enterprise"
 
-ami_id = "<A_SUPPORTED_RHEL_AMI_ID>"
+  domain_name          = "<DOMAIN_NAME>"
+  license_path         = "<PATH_TO_LOCAL_LICENSE>"
+  acm_certificate_arn  = "<EXISTING_ACM_CERTIFICATE_ARM>"
 
-proxy_ip = "<IP_FOR_PROXY_AND_PORT>"
+  # Leverages an AWS Key Pair for the accessing the Bastion instance
+  bastion_keypair = "<AWS_KEYPAIR_NAME>"
 
-load_balancing_scheme = "PRIVATE"
+  ami_id = "<A_SUPPORTED_RHEL_AMI_ID>"
 
-# Configure Redis security
-redis_encryption_in_transit = true
-redis_require_password      = true
-redis_encryption_at_rest    = false
+  proxy_ip = "<IP_FOR_PROXY_AND_PORT>"
+
+  load_balancing_scheme = "PRIVATE"
+
+  # Configure Redis security
+  redis_encryption_in_transit = true
+  redis_require_password      = true
+  redis_encryption_at_rest    = false
+}
 ```
 
 With the configuration created, run `terraform init` and `terraform apply` to provision the example infrastructure.

--- a/examples/personas-retailer/main.tf
+++ b/examples/personas-retailer/main.tf
@@ -52,7 +52,7 @@ module "retailer_deployment" {
   deploy_bastion  = true
   bastion_keypair = var.existing_aws_keypair
 
-  proxy_ip = "${aws_instance.proxy.private_ip}:${http_proxy_port}"
+  proxy_ip = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
 
   ami_id = data.aws_ami.rhel.id
 

--- a/examples/personas-retailer/versions.tf
+++ b/examples/personas-retailer/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/examples/personas-retailer/versions.tf
+++ b/examples/personas-retailer/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/examples/personas-startup/README.md
+++ b/examples/personas-startup/README.md
@@ -37,15 +37,24 @@ not be used. Therefore when deploying, the existing VPC must have:
     values of the required variables:
 
 ```hcl
-domain_name          = "<DOMAIN_NAME>"
-license_path         = "<PATH_TO_LOCAL_LICENSE>"
-acm_certificate_arn  = "<EXISTING_ACM_CERTIFICATE_ARM>"
+provider "aws" {
+  region = "<your AWS region>"
+}
 
-# Leverages an AWS Key Pair for the accessing the Bastion instance
-bastion_keypair = "rruiz-testing"
+module "aws_startup_persona" {
+  source = "git@github.com:hashicorp/terraform-aws-terraform-enterprise"
 
-# Creates a public load balancer
-load_balancing_scheme = "PUBLIC"
+  domain_name          = "<DOMAIN_NAME>"
+  license_path         = "<PATH_TO_LOCAL_LICENSE>"
+  acm_certificate_arn  = "<EXISTING_ACM_CERTIFICATE_ARM>"
+
+  # Leverages an AWS Key Pair for the accessing the Bastion instance
+  bastion_keypair = "<KEYPAIR_NAME>"
+  
+  # Creates a public load balancer
+  load_balancing_scheme = "PUBLIC"
+}
+
 ```
 
 With the configuration created, run `terraform init` and `terraform apply` to provision the example infrastructure.

--- a/examples/personas-startup/versions.tf
+++ b/examples/personas-startup/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/examples/personas-startup/versions.tf
+++ b/examples/personas-startup/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/main.tf
+++ b/main.tf
@@ -1,25 +1,3 @@
-terraform {
-  required_version = ">= 0.13"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.10.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1.2"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.0.0"
-    }
-  }
-}
-
 data "aws_region" "current" {}
 
 data "aws_ami" "ubuntu" {

--- a/modules/application_load_balancer/versions.tf
+++ b/modules/application_load_balancer/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/application_load_balancer/versions.tf
+++ b/modules/application_load_balancer/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/bastion/versions.tf
+++ b/modules/bastion/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/bastion/versions.tf
+++ b/modules/bastion/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/network_load_balancer/versions.tf
+++ b/modules/network_load_balancer/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/network_load_balancer/versions.tf
+++ b/modules/network_load_balancer/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/object_storage/versions.tf
+++ b/modules/object_storage/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/object_storage/versions.tf
+++ b/modules/object_storage/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/secrets_manager/versions.tf
+++ b/modules/secrets_manager/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/secrets_manager/versions.tf
+++ b/modules/secrets_manager/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/service_accounts/versions.tf
+++ b/modules/service_accounts/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/service_accounts/versions.tf
+++ b/modules/service_accounts/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/user_data/versions.tf
+++ b/modules/user_data/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/user_data/versions.tf
+++ b/modules/user_data/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/vm/versions.tf
+++ b/modules/vm/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/vm/versions.tf
+++ b/modules/vm/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.1.2"
+      version = "~> 2.1"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Background

This PR defines Terraform and provider requirements within each module but does not configure the providers.

Side note: The plan also caught a missing `local.` namespace in the retailer example that is fixed in this PR.

Relates OR Closes:
[[AWS] Define Terraform and provider requirements; remove provider configurations](https://app.asana.com/0/1181500399442529/1200126427307415/f)

## How Has This Been Tested

The three example modules passed a `terraform init/validate/plan`

### Test Configuration

* Terraform Version: 0.13.6