### PR TITLE
Add in dispatcher and handlers for slash commands

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -1,18 +1,20 @@
 name: Pull Request Dispatcher
+
 on:
-  issue_comment:
-    types:
-      - created
+  issue_comment:
+    types:
+      - created
+
 jobs:
-  slash_command_dispatch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v2
-        with:
-          token: ${{ secrets.PAT }}
-          commands: |
-            init
-          permission: maintain
-          issue-type: pull_request
-          event-type-suffix: -command
+  slash_command_dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+        commands: |
+          init
+        permission: maintain
+        issue-type: pull_request
+        event-type-suffix: -command

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -1,0 +1,18 @@
+name: Pull Request Dispatcher
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  slash_command_dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          commands: |
+            init
+          permission: maintain
+          issue-type: pull_request
+          event-type-suffix: -command

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
         commands: |
-          init
+          test
         permission: maintain
         issue-type: pull_request
         event-type-suffix: -command

--- a/.github/workflows/handler.yml
+++ b/.github/workflows/handler.yml
@@ -1,22 +1,26 @@
 name: Pull Request Handler
+
 on:
-  repository_dispatch:
-    types:
-      - test-command
+  repository_dispatch:
+    type:
+      - test-command
+
 jobs:
-  init:
-    name: Initialize Terraform
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
-      - name: Terraform Init
-        working-directory: ./tests/public-install
-        run: terraform init -input=false -no-color
+  tf_init:
+    name: Run tf-init
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: 0.14.8
+          terraform_wrapper: true
+
+      - name: Terraform Init
+        working-directory: ./tests/public-install
+        run: terraform init -input=false -no-color

--- a/.github/workflows/handler.yml
+++ b/.github/workflows/handler.yml
@@ -1,0 +1,22 @@
+name: Pull Request Handler
+on:
+  repository_dispatch:
+    types:
+      - test-command
+jobs:
+  init:
+    name: Initialize Terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: 0.14.8
+          terraform_wrapper: true
+      - name: Terraform Init
+        working-directory: ./tests/public-install
+        run: terraform init -input=false -no-color

--- a/tests/public-install/versions.tf
+++ b/tests/public-install/versions.tf
@@ -1,5 +1,11 @@
 terraform {
-  backend "remote" {}
+  backend "remote" {
+    organization = "terraform-enterprise-modules-test"
+
+    workspaces {
+      name = "aws-public-active-active"
+    }
+  }
   required_version = ">= 0.13"
   required_providers {
     random = {

--- a/tests/public-install/versions.tf
+++ b/tests/public-install/versions.tf
@@ -2,21 +2,9 @@ terraform {
   backend "remote" {}
   required_version = ">= 0.13"
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.10"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## Background

This work is tied to the [[AWS] Create GitHub Actions configuration for Terraform initialization of pull requests][asana] :lock:.

[asana]: https://app.asana.com/0/1181500399442529/1200106415052877/f

## How Has This Been Tested

~~This will be tested in this pull request with Slash commands issued by maintainers.~~

```sh
act repository_dispatch -j tf_init -s "TF_API_TOKEN=<REDACTED>"

# redacted output for brevity...
[Pull Request Handler/Run tf-init]   ⚙  ::set-output:: stderr=
[Pull Request Handler/Run tf-init]   ⚙  ::set-output:: exitcode=0
[Pull Request Handler/Run tf-init]   ✅  Success - Terraform Init

```

### Test Configuration

* Terraform Version: 0.14.7
* Any additional relevant variables:

## This PR makes me feel

![George Lopez behind a laptop saying That's Terrifying](https://media.giphy.com/media/3ohzdKFMfGO7aE07AI/giphy.gif)
