### PR TITLE
Replace the underscore with a dash

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -17,5 +17,5 @@ jobs:
           commands: |
             test
           permission: maintain
-          issue-type: pull_request
+          issue-type: pull-request
           event-type-suffix: -command


### PR DESCRIPTION
## Background

When I fixed the indentation in #105 and introduced the changes in #100, the copy-pasta from the ticket didn't have the right `issue-type` with dashes rather than underscores. 

## How Has This Been Tested

Manually testing by running `/test` in other PRs.

### Test Configuration

* Terraform Version: n/a