### PR TITLE
Add in a help command

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -16,6 +16,7 @@ jobs:
           token: ${{ secrets.PAT }}
           commands: |
             test
+            help
           permission: maintain
           issue-type: pull-request
           event-type-suffix: -command

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -19,6 +19,6 @@ jobs:
           body: |
             > Command | Description
             > --- | ---
-            > /test | Run the Terraform test suite on the module's tests/ directory
+            > /test | Run the Terraform test workflow on the modules in the tests/ directory
             > /help | Shows this help message
           reaction-type: hooray

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -1,0 +1,24 @@
+name: Pull Request Help Handler
+
+on:
+  repository_dispatch:
+    types:
+      - help-command
+
+jobs:
+  help:
+    name: Run help
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            > Command | Description
+            > --- | ---
+            > /test | Run the Terraform test suite on the module's tests/ directory
+            > /help | Shows this help message
+          reaction-type: hooray


### PR DESCRIPTION
## Background

Add in a `/help` command so that maintainers know how to use the command in case they forget.

## How Has This Been Tested

Since this is a `/slash` command, it will have to be tested after it's merged in.

### Test Configuration

* Terraform Version: n/a
* Any additional relevant variables: n/a

## This PR makes me feel

![Pee Wee holds up Word of the Day HELP](https://media.giphy.com/media/IoXVrbzUIuvTy/giphy.gif)