### PR TITLE
Fix up test feedback

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -36,11 +36,6 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
-        # Add stdout and stderr to the environment variables to be used in the
-        # message from the TFE bot.
-        env:
-          INIT_STDOUT: "terraform\n${{ steps.init.outputs.stdout }}"
-          INIT_STDERR: "terraform\n${{ steps.init.outputs.stderr }}"
         with:
           token: ${{ secrets.PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -55,8 +50,9 @@ jobs:
             <b>Terraform Initialization Output</b> ⚙️
             </summary>
 
-            \`\`\`${process.env.INIT_STDOUT}\`\`\`
-            \`\`\`${process.env.INIT_STDERR}\`\`\`
+            ```${{ steps.init.outputs.stdout }}```
+
+            ```${{ steps.init.outputs.stderr }}```
 
             </details>
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
             #### Terraform Test Report 📰
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -41,14 +41,14 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            #### Terraform Test Report 📰
+            #### Terraform Test Report :newspaper:
 
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Initialization :gear: `${{ steps.init.outcome }}`
 
             <details>
-            <summary>
-            <b>Terraform Initialization Output</b> ⚙️
-            </summary>
+              <summary>
+                <b>Terraform Initialization Output</b> :gear:
+              </summary>
 
             ```${{ steps.init.outputs.stdout }}```
 
@@ -56,6 +56,6 @@ jobs:
 
             </details>
 
-            [Action Run Page][1]
+            :link: [Action Run Page][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}


### PR DESCRIPTION
## Background

The #111 work added feedback to the `/test` command, but it wasn't quite perfect. This patch series cleans it up a bit and adds the ability for the bot to update the `/slash` command comment rather than generating it's own comment.

## How Has This Been Tested

This is being tested in #113 manually after successfully merging this PR into the default branch.

### Test Configuration

* Terraform Version: n/a
* Any additional relevant variables: n/a

## This PR makes me feel

![Character from Mad Men says that they tried communicating without words but it wasn't working](https://media.giphy.com/media/jd4YLfyVaHqik/giphy.gif)
