### PR TITLE
Replacing horizontal line with bot username

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -41,8 +41,8 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
+            :computer: @hc-team-tfe
 
-            ---
             ### Terraform Test Report :newspaper:
 
             #### Terraform Initialization :gear: `${{ steps.init.outcome }}`


### PR DESCRIPTION
## Background

Doing this because the `---` horizontal line causes the last line of the
command comment to be an `<h1>` rather than creating the line properly.

## How Has This Been Tested

:eyes: #113

### Test Configuration

* Terraform Version: n/a
* Any additional relevant variables: n/a

## This PR makes me feel

![Furiously writing](https://media.giphy.com/media/TvcA7FhoV7UJy/giphy.gif)
