### PR TITLE
Checkout branch of PR under test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -14,8 +14,12 @@ jobs:
         id: vars
         run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
+      # Checkout the branch of the pull request under test
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
## Background

This branch adjusts the handler for the test command to checkout the branch of the pull request so that we aren't just testing the main branch :sweat_smile:. The pull request attributes were gleaned from [slash-command-dispatch documentation](https://github.com/peter-evans/slash-command-dispatch/#github-and-pull_request-contexts) and [GitHub documentation](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request).


Relates #113


## How Has This Been Tested

Due to the nature of the slash command action, this must be tested post-merge.

## This PR makes me feel

![An owl thinking](https://media0.giphy.com/media/s68CylvQ9ioRa/giphy.gif?cid=5a38a5a26c1w4bzkrglro26x5qtl459wzidl73ju6qt23luc&rid=giphy.gif&ct=g)