### PR TITLE
Always run update comment step

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -39,6 +39,7 @@ jobs:
       # Run Terraform commands between these comments ^^^
 
       - name: Update comment
+        if: ${{ always() }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Background

This branch changes the 'Update comment' step to always run, so that failures are reported.


Relates #117


## How Has This Been Tested

This will be tested in #118 once it is merged.

## This PR makes me feel

![A penguin embracing the bad things](https://media3.giphy.com/media/6yh8zdYiboEpy/giphy.gif?cid=5a38a5a228oc7f7byb87uoxeiy20ut5i2acrzu8ngqrjjbhu&rid=giphy.gif&ct=g)
