### PR TITLE
Add AWS_DEFAULT_REGION to terraform validate

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Terraform Validate
         id: validate
         working-directory: ./tests/public-install
+        env:
+          AWS_DEFAULT_REGION: us-west-2
         run: terraform validate -no-color
 
       # Run Terraform commands between these comments ^^^


### PR DESCRIPTION
## Background

This branch defines AWS_DEFAULT_REGION for the Terraform Validate step so that it does not fail due to missing provider configuration.


Relates #121


## How Has This Been Tested

This will be verified in #121 post-merge.

## This PR makes me feel

![Principal Skinner saying "Yes. It's a regional dialect."](https://media1.giphy.com/media/3o6MbjgMZihbd7YYN2/giphy.gif?cid=5a38a5a2n2ukwgmbmcbx57iv7p877f9qsri2rj24lzmpy470&rid=giphy.gif&ct=g)
