### PR TITLE
Remove /command syntax from help message

### DIFF
--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -17,8 +17,9 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
+            > The following slash commands are available:
             > Command | Description
             > --- | ---
-            > /test | Run the Terraform test workflow on the modules in the tests/ directory
-            > /help | Shows this help message
+            > test | Run the Terraform test workflow on the modules in the tests/ directory
+            > help | Shows this help message
           reaction-type: hooray


### PR DESCRIPTION
## Background

The help command is triggering the test command. While the [slash-command-dispatch README](https://github.com/peter-evans/slash-command-dispatch#how-comments-are-parsed-for-slash-commands) states that only the first line of a comment is parsed for a slash command, it's not clear why else the help command is triggering the test command other than including the slash command in its output. :shrug: This branch modifies the help output to see if the issue is resolved.


Relates #113


## How Has This Been Tested

This will be tested post-merge.

## This PR makes me feel

![Barack Obama wondering why slash-command-dispatch is misbehaving](https://media1.giphy.com/media/pPhyAv5t9V8djyRFJH/200.gif?cid=5a38a5a2uqiaxb4mqoptwi17m1pbfhklh6yt5eux69lq908c&rid=200.gif&ct=g)
