### PR TITLE
Fix `types` argument of handler-test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -2,7 +2,7 @@ name: Pull Request Test Handler
 
 on:
   repository_dispatch:
-    type:
+    types:
       - test-command
 
 jobs:


### PR DESCRIPTION
## Background

`handler-test.yml` had a syntax error of `type` instead of `types` which caused it to respond to every dispatched command.

Relates #113


## This PR makes me feel

![syntax error](https://media4.giphy.com/media/ifdPjn6m4WyNlnXMTj/giphy.gif?cid=5a38a5a2xut2hgev8k67cg9sidn52ue3lqdc5mxb9wfu2evh&rid=giphy.gif&ct=g)
