### PR TITLE
Plumb bastion into VM module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -223,6 +223,7 @@ module "vm" {
   aws_lb                              = var.load_balancing_scheme == "PRIVATE_TCP" ? null : module.load_balancer[0].aws_lb_security_group
   aws_lb_target_group_tfe_tg_443_arn  = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_443_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_443_arn
   aws_lb_target_group_tfe_tg_8800_arn = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn
+  deploy_bastion                      = var.deploy_bastion
   bastion_key                         = local.bastion_key_public
   bastion_sg                          = local.bastion_sg
   default_ami_id                      = local.default_ami_id

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -37,6 +37,7 @@ resource "aws_security_group_rule" "tfe_outbound" {
 }
 
 resource "aws_security_group_rule" "tfe_bastion_ssh_allow" {
+  count                    = var.deploy_bastion ? 1 : 0
   security_group_id        = aws_security_group.tfe_instance.id
   type                     = "ingress"
   from_port                = 22
@@ -60,7 +61,7 @@ resource "aws_launch_configuration" "tfe" {
   name_prefix   = "${var.friendly_name_prefix}-tfe-ec2-asg-lt-"
   image_id      = var.ami_id
   instance_type = var.instance_type
-  key_name      = var.bastion_key
+  key_name      = var.deploy_bastion ? var.bastion_key : null
   user_data     = var.userdata_script
 
   iam_instance_profile = var.aws_iam_instance_profile

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -37,6 +37,12 @@ variable "aws_iam_instance_profile" {
   type        = string
 }
 
+variable "deploy_bastion" {
+  type        = bool
+  description = "(Optional) Boolean indicating whether to deploy a Bastion instance (true) or not (false). Only specify true if deploy_vpc is true."
+  default     = true
+}
+
 variable "bastion_sg" {
   description = "The identity of the security group attached to the bastion EC2 instance."
   type        = string

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -10,24 +10,24 @@ variable "userdata_script" {
 
 variable "aws_lb" {
   description = <<-EOD
-  The identity of the security group attached to the load balancer which will be authorized to communicate with the TFE 
-  EC2 instance(s).
+  The identity of the security group attached to the load balancer which will be
+  authorized to communicate with the TFE EC2 instance(s).
   EOD
   type        = string
 }
 
 variable "aws_lb_target_group_tfe_tg_443_arn" {
   description = <<-EOD
-  The Amazon Resource Name of the load balancer target group for traffic on port 443 which will be backed by the TFE 
-  EC2 autoscaling group.
+  The Amazon Resource Name of the load balancer target group for traffic on port
+  443 which will be backed by the TFE EC2 autoscaling group.
   EOD
   type        = string
 }
 
 variable "aws_lb_target_group_tfe_tg_8800_arn" {
   description = <<-EOD
-  The Amazon Resource Name of the load balancer target group for traffic on port 8800 which will be backed by the TFE 
-  EC2 autoscaling group.
+  The Amazon Resource Name of the load balancer target group for traffic on port
+  8800 which will be backed by the TFE EC2 autoscaling group.
   EOD
   type        = string
 }


### PR DESCRIPTION
## Background

Discovered in the test for #126 that the bastion setup was still occurring in the VM module. This adds a couple of ternary operators to the VM module to prevent it from setting anything Bastion related if the module is created with a `deploy_bastion = false` property

## How Has This Been Tested

This was tested locally by planning and applying and destroying infrastructure locally.

### Test Configuration

* Terraform Version n/a
* Any additional relevant variables: n/a

## This PR makes me feel

![Mario aggressively plumbing a pipe.](https://media.giphy.com/media/WR9adQvRKA9kGcdI8w/giphy.gif)
