### PR TITLE
Wait for TFE

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -1,5 +1,9 @@
 name: Pull Request Test Handler
 
+# This is used to define anchors for repeated keys or configuration blocks.
+tfe_parameters:
+  working-directory: &PUBLIC_WORK_DIR ./tests/public-install
+
 on:
   repository_dispatch:
     types:
@@ -33,24 +37,24 @@ jobs:
 
       - name: Terraform Init
         id: init
-        working-directory: ./tests/public-install
+        working-directory: *PUBLIC_WORK_DIR
         run: terraform init -input=false -no-color
 
       - name: Terraform Validate
         id: validate
-        working-directory: ./tests/public-install
+        working-directory: *PUBLIC_WORK_DIR
         env:
           AWS_DEFAULT_REGION: us-east-2
         run: terraform validate -no-color
 
       - name: Terraform Apply
         id: apply
-        working-directory: ./tests/public-install
+        working-directory: *PUBLIC_WORK_DIR
         run: terraform apply -auto-approve -input=false -no-color
 
       - name: Terraform Destroy
         id: destroy
-        working-directory: ./tests/public-install
+        working-directory: *PUBLIC_WORK_DIR
         run: terraform destroy -auto-approve -input=false -no-color
 
       # Run Terraform commands between these comments ^^^

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -52,6 +52,14 @@ jobs:
         working-directory: *PUBLIC_WORK_DIR
         run: terraform apply -auto-approve -input=false -no-color
 
+      - name: Wait For TFE
+        id: wait-for-tfe
+        working-directory: *PUBLIC_WORK_DIR
+        timeout-minutes: 15
+        run: |
+          echo "Curling \`health_check_url\` for a return status of 200..."
+          while ! curl -sfS --max-time 5 $( terraform output health_check_url ); do sleep 5; done
+
       - name: Terraform Destroy
         id: destroy
         working-directory: *PUBLIC_WORK_DIR

--- a/outputs.tf
+++ b/outputs.tf
@@ -93,3 +93,8 @@ output "login_url" {
   value       = "https://${local.fqdn}/admin/account/new?token=${module.user_data.user_token.value}"
   description = "Login URL to setup the TFE instance once it is initialized"
 }
+
+output "health_check_url" {
+  value       = "https://${local.fqdn}/_health_check"
+  description = "The URL to access the TFE instance health check."
+}

--- a/tests/public-install/outputs.tf
+++ b/tests/public-install/outputs.tf
@@ -2,3 +2,8 @@ output "public_install" {
   value       = module.public_install
   description = "The output of all the public_install module."
 }
+
+output "health_check_url" {
+  value       = module.public_install.health_check_url
+  description = "The health check URL for TFE."
+}


### PR DESCRIPTION
## Background

In #125 the Apply an Destroy commands run properly, but there should be a delay to wait for TFE to come up properly before doing the destroy. This step times out after 15m, which is roughly 2x the amount of time it normally takes for TFE to come up in my local testing.

This patch also adds a YAML anchor for the `tests/public-install` directory because it is used in multiple steps.

## How Has This Been Tested

This will be tested in a separate PR comment because it's a `/test` command.

### Test Configuration

* Terraform Version: n/a
* Any additional relevant variables: n/a

## This PR makes me feel

![Dog waits for commands to run and complete on a laptop.](https://media.giphy.com/media/1kkxWqT5nvLXupUTwK/giphy.gif)
