### PR TITLE
Add k6 Smoke Tests

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           K6_PATHNAME: "./k6"
           TFE_URL: "${{ steps.retrieve-tfe-url.stdout }}"
-          TFE_API_TOKEN: "${{ steps.retrieve-iact-token.stdout }}"
+          TFE_API_TOKEN: "${{ steps.create-admin.stdout }}"
           TFE_EMAIL: tf-onprem-team@hashicorp.com
         run: |
           make smoke-test

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -2,7 +2,9 @@ name: Pull Request Test Handler
 
 # This is used to define anchors for repeated keys or configuration blocks.
 tfe_parameters:
-  working-directory: &PUBLIC_WORK_DIR ./tests/public-install
+  working-directories:
+    public: &PUBLIC_WORK_DIR ./tests/public-install
+    k6: &K6_WORK_DIR ./tests/tfe-load-test
 
 on:
   repository_dispatch:

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -18,7 +18,7 @@ jobs:
         id: vars
         run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
-      # Checkout the branch of the pull request under test
+      # Checkout the branch of the pull request under tests/
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -27,6 +27,22 @@ jobs:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
 
+      # Checkout the hashicorp/tfe-load-test repository
+      - name: Checkout TFE Load Test
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
+          path: *K6_WORK_DIR
+          repository: hashicorp/tfe-load-test
+          token: ${{ secrets.PAT }}
+
+      - name: Install required tools
+        env:
+          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
+        run: |
+          sudo apt-get install jq
+          curl -L $K6_URL | tar xyz --strip-components
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
@@ -61,6 +77,35 @@ jobs:
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl -sfS --max-time 5 $( terraform output health_check_url ); do sleep 5; done
+
+      - name: Retrieve TFE URL
+        id: retrieve-tfe-url
+        run: |
+          terraform output -no-color -raw tfe_url
+
+      - name: Retrieve IACT Token
+        id: retrieve-iact-token
+        run: |
+          curl $( terraform output -no-color -raw iact_url )
+
+      - name: Create Admin in TFE
+        id: create-admin
+        run: |
+          curl \
+            --header "Content-Type: application/json" \
+            --data '{ "username": "tester", "email": "tf-onprem-team@hashicorp", "password": "${{ secrets.TFE_PASSWORD }}" }' \
+            $( terraform output -no-color -raw initial_admin_user_url )?token=${{ steps.retrieve-iact-token.stdout }} \
+            | jq --raw-output '.token'
+
+      - name: Run k6 Smoke Tests
+        working-directory: *K6_WORK_DIR
+        env:
+          K6_PATHNAME: "./k6"
+          TFE_URL: "${{ steps.retrieve-tfe-url.stdout }}"
+          TFE_API_TOKEN: "${{ steps.retrieve-iact-token.stdout }}"
+          TFE_EMAIL: tf-onprem-team@hashicorp.com
+        run: |
+          make smoke-test
 
       - name: Terraform Destroy
         id: destroy

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -98,6 +98,7 @@ jobs:
             | jq --raw-output '.token'
 
       - name: Run k6 Smoke Tests
+        id: run-smoke-tests
         working-directory: *K6_WORK_DIR
         env:
           K6_PATHNAME: "./k6"
@@ -164,6 +165,20 @@ jobs:
             ```
             ${{ steps.apply.outputs.stdout }}
             ${{ steps.apply.outputs.stderr }}
+            ```
+
+            </details>
+
+            #### K6 Smoke Tests :building_construction: `${{ steps.run-smoke-tests.outcome }}`
+
+            <details>
+              <summary>
+                <b>K6 Smoke Tests Output</b> :building_construction:
+              </summary>
+
+            ```
+            ${{ steps.run-smoke-tests.outputs.stdout }}
+            ${{ steps.run-smoke-tests.outputs.stderr }}
             ```
 
             </details>

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -1,11 +1,5 @@
 name: Pull Request Test Handler
 
-# This is used to define anchors for repeated keys or configuration blocks.
-tfe_parameters:
-  working-directories:
-    public: &PUBLIC_WORK_DIR ./tests/public-install
-    k6: &K6_WORK_DIR ./tests/tfe-load-test
-
 on:
   repository_dispatch:
     types:
@@ -15,6 +9,9 @@ jobs:
   public_install:
     name: Run tf-test on Public Install
     runs-on: ubuntu-latest
+    env:
+      WORK_DIR_PATH: ./tests/public-install
+      K6_WORK_DIR_PATH: ./tests/tfe-load-test
     steps:
       - name: Create URL to the run output
         id: vars
@@ -32,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: 'master'
-          path: *K6_WORK_DIR
+          path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.PAT }}
 
@@ -55,24 +52,24 @@ jobs:
 
       - name: Terraform Init
         id: init
-        working-directory: *PUBLIC_WORK_DIR
+        working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform init -input=false -no-color
 
       - name: Terraform Validate
         id: validate
-        working-directory: *PUBLIC_WORK_DIR
+        working-directory: ${{ env.WORK_DIR_PATH }}
         env:
           AWS_DEFAULT_REGION: us-east-2
         run: terraform validate -no-color
 
       - name: Terraform Apply
         id: apply
-        working-directory: *PUBLIC_WORK_DIR
+        working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform apply -auto-approve -input=false -no-color
 
       - name: Wait For TFE
         id: wait-for-tfe
-        working-directory: *PUBLIC_WORK_DIR
+        working-directory: ${{ env.WORK_DIR_PATH }}
         timeout-minutes: 15
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
@@ -99,7 +96,7 @@ jobs:
 
       - name: Run k6 Smoke Tests
         id: run-smoke-tests
-        working-directory: *K6_WORK_DIR
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
         env:
           K6_PATHNAME: "./k6"
           TFE_URL: "${{ steps.retrieve-tfe-url.stdout }}"
@@ -110,7 +107,7 @@ jobs:
 
       - name: Terraform Destroy
         id: destroy
-        working-directory: *PUBLIC_WORK_DIR
+        working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform destroy -auto-approve -input=false -no-color
 
       # Run Terraform commands between these comments ^^^

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -20,7 +20,7 @@ jobs:
         id: vars
         run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
-      # Checkout the branch of the pull request under tests/
+      # Checkout the branch of the pull request being tested
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/outputs.tf
+++ b/outputs.tf
@@ -94,7 +94,7 @@ output "login_url" {
   description = "Login URL to setup the TFE instance once it is initialized"
 }
 
-output "health_check_url" {
-  value       = "https://${local.fqdn}/_health_check"
-  description = "The URL to access the TFE instance health check."
+output "tfe_url" {
+  value       = "https://${local.fqdn}/"
+  description = "The URL to the TFE application."
 }

--- a/tests/public-install/outputs.tf
+++ b/tests/public-install/outputs.tf
@@ -3,7 +3,22 @@ output "public_install" {
   description = "The output of all the public_install module."
 }
 
+output "tfe_url" {
+  value       = module.public_install.tfe_url
+  description = "The URL to the TFE application."
+}
+
 output "health_check_url" {
-  value       = module.public_install.health_check_url
-  description = "The health check URL for TFE."
+  value       = "${module.public_install.tfe_url}/_health_check"
+  description = "The URL with path to access the TFE instance health check."
+}
+
+output "iact_url" {
+  value       = "${module.public_install.tfe_url}/admin/retrieve-iact"
+  description = "The URL with path to access the TFE instance Retrieve IACT."
+}
+
+output "initial_admin_user_url" {
+  value       = "${module.public_install.tfe_url}/admin/initial-admin-user"
+  description = "The URL with path to access the TFE instance Initial Admin User."
 }


### PR DESCRIPTION
## Background

This patch series adds the K6 smoke tests from `hashicorp/tfe-load-test` and sets things up for `/test` commands to run them.

## How Has This Been Tested

Since this is a `/test` command, it'll need to be tested in another PR with a comment of `/test` by a maintainer.

### Test Configuration

* Terraform Version: n/a
* Any additional relevant variables: n/a

## This PR makes me feel

![A car with smoking tires ready to go, but not moving.](https://media.giphy.com/media/CDqlUoHvkzM52/giphy.gif)
