### PR TITLE
Fix tar arguments for extracting k6

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -38,7 +38,7 @@ jobs:
           K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
         run: |
           sudo apt-get install jq
-          curl -L $K6_URL | tar xyz --strip-components
+          curl -L $K6_URL | tar -xz --strip-components=1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
## Background

#129 added k6 to the testing workflow, but it had some bugs within the tar command that unpacks the k6 archive. This branch fixes those bugs.


## How Has This Been Tested

These changes will be tested in #130 once this pull request is merged. I also verified the fixed syntax locally.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/xFkeJnpEBhRHBrfurY/200.gif?cid=5a38a5a2gan1h8vlzql9hn6aq996hmldiabsc7340kfk9rol&rid=200.gif&ct=g)
