### PR TITLE
Combine read CIDRs and write vars

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -62,17 +62,12 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
         run: terraform validate -no-color
 
-      - name: Retrieve GitHub Actions CIDRs
-        id: retrieve-github-actions-cidrs
-        run: |
-          echo "::set-output name=list::$( \
-            curl -H 'Accept: application/vnd.github.v3+json' https://api.github.com/meta | jq .actions | tr -d '\n' )"
-      
-      - name: Write Terraform Variables
-        id: write-terraform-variables
+      - name: Write GitHub Actions CIDRs to Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
-          echo "iact_subnet_list = ${{ steps.retrieve-github-actions-cidrs.outputs.list }}" > github.auto.tfvars
+          echo "iact_subnet_list = $( \
+            curl -H 'Accept: application/vnd.github.v3+json' https://api.github.com/meta | jq .actions | tr -d '\n' )" \
+            > github.auto.tfvars
 
       - name: Terraform Apply
         id: apply


### PR DESCRIPTION
## Background

Separating the step that reads the GitHub Actions CIDRs from the step that wrote them to a variables file resulted in the quotes being stripped from each list element, which was invalid HCL syntax. :shrug: This branch combines those steps so that the quotes are preserved.


## How Has This Been Tested

I have tested this combined command locally and saw valid HCL as a result, which was accepted by a remote Terraform speculative plan. This will also be tested in #130.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/c81IRQDtJFUxc2UvMO/giphy.gif?cid=5a38a5a28pbcpnx7pmzebbhohkr71kvgftdhkg98j6dvut78&rid=giphy.gif&ct=g)