### PR TITLE
Write a CIDR mask for the current IP address

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -63,12 +63,10 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
         run: terraform validate -no-color
 
-      - name: Write GitHub Actions CIDRs to Terraform Variables
+      - name: Write GitHub Actions runner CIDR to Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
-          echo "iact_subnet_list = $( \
-            curl -H 'Accept: application/vnd.github.v3+json' https://api.github.com/meta | jq .actions | tr -d '\n' )" \
-            > github.auto.tfvars
+          echo "iact_subnet_list = [\"$( dig +short @resolver1.opendns.com myip.opendns.com )/32\"]" > github.auto.tfvars
 
       - name: Terraform Apply
         id: apply


### PR DESCRIPTION
## Background

GitHub's API returns too many CIDR masks to include in the user data of the TFE instance so this branch attempts to provide a CIDR mask for only the IP address of the current runner.  

Failed test due to user data size: https://github.com/hashicorp/terraform-aws-terraform-enterprise/runs/2469322832?check_suite_focus=true#step:10:1360

## How Has This Been Tested

This will be tested in #130.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/3oKIPrwk5SCKWexkLS/giphy.gif?cid=5a38a5a2g7c03ssr3j43mbx6iohp11kmd6egcmtk73a94htb&rid=giphy.gif&ct=g)
