### PR TITLE
Write admin user payload to file

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -112,13 +112,12 @@ jobs:
       - name: Create Admin in TFE
         id: create-admin
         run: |
+          echo '{"username": "test", "email": "tf-onprem-team@hashicorp", "password": "${{ secrets.TFE_PASSWORD }}"}' \
+            > payload.json
           echo "::set-output name=token::$( \
             curl \
             --header 'Content-Type: application/json' \
-            --data '{ \
-              \"username\": \"tester\", \
-              \"email\": \"tf-onprem-team@hashicorp\", \
-              \"password\": \"${{ secrets.TFE_PASSWORD }}\" }' \
+            --data @./payload.json \
             ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}?token=${{ steps.retrieve-iact.outputs.token }} \
             | jq --raw-output '.token' )"
 


### PR DESCRIPTION
## Background

In the test workflow, the inclusion of the admin payload inline with the curl command caused an error due to formatting. This branch writes the payload to a file first.

## How Has This Been Tested

I verified the validity of the payload.json creation locally. This will be tested with #130.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/8WeatsYCC54TC/giphy.gif?cid=5a38a5a2kzm7m2vnhtzagh9gnhd0ebb97vnnzucmpmxrdmyo&rid=giphy.gif&ct=g)
