### PR TITLE
Add TLD to admin email address

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -112,8 +112,9 @@ jobs:
       - name: Create Admin in TFE
         id: create-admin
         run: |
-          echo '{"username": "test", "email": "tf-onprem-team@hashicorp", "password": "${{ secrets.TFE_PASSWORD }}"}' \
-            > payload.json
+          echo \
+            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "${{ secrets.TFE_PASSWORD }}"}' \
+            > ./payload.json
           echo "::set-output name=token::$( \
             curl \
             --header 'Content-Type: application/json' \


### PR DESCRIPTION
## Background

The admin email address in the test workflow was missing a TLD. This branch fixes that issue.

## How Has This Been Tested

To be tested in #130.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/YmjleYhDTUiYw/giphy.gif?cid=5a38a5a2gijkswhoifn5cmaoat7gs1r5sx2wgtp94qixvphx&rid=giphy.gif&ct=g)
