### PR TITLE
Add metadata options to VM launch configuration

### DIFF
--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -67,6 +67,13 @@ resource "aws_launch_configuration" "tfe" {
   iam_instance_profile = var.aws_iam_instance_profile
   security_groups      = [aws_security_group.tfe_instance.id]
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    # A hop limit of at least 2 is required for AWS Cost Estimation to function.
+    http_put_response_hop_limit = 2
+    http_tokens                 = "optional"
+  }
+
   root_block_device {
     encrypted             = true
     volume_type           = "gp2"

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -68,7 +68,7 @@ resource "aws_launch_configuration" "tfe" {
   security_groups      = [aws_security_group.tfe_instance.id]
 
   metadata_options {
-    http_endpoint               = "enabled"
+    http_endpoint = "enabled"
     # A hop limit of at least 2 is required for AWS Cost Estimation to function.
     http_put_response_hop_limit = 2
     http_tokens                 = "optional"


### PR DESCRIPTION
## Background

When using an IAM instance profile to authenticate Cost Estimation for AWS resources, a metadata HTTP PUT response hop limit of at least 2 is required to account for the use of IMDSv1.

## How Has This Been Tested

Deployed and verified that Cost Estimation worked for AWS resources using an IAM instance profile.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/xT5LMJ8ay1bH2EoJ2g/giphy.gif?cid=5a38a5a2x768a17278im6cn4i95sv33oqc55ojb79vdmb0at&rid=giphy.gif&ct=g)
