### PR TITLE
Split create-admin step

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -115,12 +115,17 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "${{ secrets.TFE_PASSWORD }}"}' \
             > ./payload.json
-          echo "::set-output name=token::$( \
+          echo "::set-output name=response::$( \
             curl \
+            --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \
-            ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}?token=${{ steps.retrieve-iact.outputs.token }} \
-            | jq --raw-output '.token' )"
+            ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}?token=${{ steps.retrieve-iact.outputs.token }})"
+
+      - name: Retrieve Admin Token
+        id: retrieve-admin-token
+        run: |
+          echo "::set-output name=token::$(echo '${{ steps.create-admin.outputs.response }}' | jq --raw-output '.token')"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test
@@ -128,7 +133,7 @@ jobs:
         env:
           K6_PATHNAME: "./k6"
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-          TFE_API_TOKEN: "${{ steps.create-admin.outputs.token }}"
+          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
           TFE_EMAIL: tf-onprem-team@hashicorp.com
         run: |
           make smoke-test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 .DS_Store
 *.bk
+
+# Editor files
+.vscode


### PR DESCRIPTION
## Background

The step to create the admin user in the test workflow is failing with an unexpected response from TFE. I was unable to reproduce the issue locally so this branch splits the step in order to expose the failure response and facilitate debugging the issue.

## How Has This Been Tested

To be tested in #130.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/3oz8xA07HKwLlpPUkM/200.gif?cid=5a38a5a22wpa0n4tn62hx4ir6fh8i7lntybqtxgrcjhll6fz&rid=200.gif&ct=g)
