### PR TITLE
Increase verbosity of retrieve-iact curl

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         run: |
-          echo "::set-output name=token::$( curl ${{ steps.retrieve-iact-url.outputs.stdout }} )"
+          echo "::set-output name=token::$( curl --verbose ${{ steps.retrieve-iact-url.outputs.stdout }} )"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url


### PR DESCRIPTION
## Background

The retrieve-iact step of the test workflow failed silently. This branch adds verbosity so we can debug the issue.

## How Has This Been Tested

This will be tested in #130.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/5xtDarE6xDVfXhudrVK/giphy.gif?cid=5a38a5a2lqz64rxcasgrsuarhqd18fosb0nws0r78ea3o194&rid=giphy.gif&ct=g)
