### PR TITLE
aaron-lane-public-active-active

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -6,11 +6,11 @@ on:
       - test-command
 
 jobs:
-  public_install:
-    name: Run tf-test on Public Install
+  public_active_active:
+    name: Run tf-test on Public Active/Active
     runs-on: ubuntu-latest
     env:
-      WORK_DIR_PATH: ./tests/public-install
+      WORK_DIR_PATH: ./tests/public-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
     steps:
       - name: Create URL to the run output


### PR DESCRIPTION
## Background

In the process of defining the next test case, I decided to take the opportunity to rename public-install to public-active-active so that it is consistently named with the various backing infrastructure bits, as well as a little more obvious about the nature of its deployment. This branch only updates the test workflow, and a subsequent branch will adjust the actual Terraform configuration which will be tested via pull request.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/xT5LMArD7QTroFSzCw/giphy.gif?cid=5a38a5a2enmoemgyooku6ypoiejgy05xo5v5els5pykgseze&rid=giphy.gif&ct=g)
