### PR TITLE
Retry curl when error responses are received

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -101,7 +101,8 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         run: |
-          echo "::set-output name=token::$( curl --verbose ${{ steps.retrieve-iact-url.outputs.stdout }} )"
+          echo "::set-output name=token::$( \
+            curl --fail --retry 5 --retry-all-errors --verbose ${{ steps.retrieve-iact-url.outputs.stdout }} )"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -117,6 +118,9 @@ jobs:
             > ./payload.json
           echo "::set-output name=response::$( \
             curl \
+            --fail \
+            --retry 5 \
+            --retry-all-errors \
             --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \


### PR DESCRIPTION
## Background

The tests for #145 failed due to curl receiving a transient 502 when attempting to create the admin user. This branch adds curl's [--retry-all-errors](https://curl.se/docs/manpage.html#--retry-all-errors) option to automatically retry when a 4XX or 5XX series error is received.

## How Has This Been Tested

To be tested in #145.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/QMMt03hAmVbNu/giphy.gif?cid=5a38a5a237wijoegswoghz352nukhyiei19aqy1ircrdckk5&rid=giphy.gif&ct=g)
