### PR TITLE
Remove --retry-all-errors

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -102,7 +102,7 @@ jobs:
         id: retrieve-iact
         run: |
           echo "::set-output name=token::$( \
-            curl --fail --retry 5 --retry-all-errors --verbose ${{ steps.retrieve-iact-url.outputs.stdout }} )"
+            curl --fail --retry 5 --verbose ${{ steps.retrieve-iact-url.outputs.stdout }} )"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -120,7 +120,6 @@ jobs:
             curl \
             --fail \
             --retry 5 \
-            --retry-all-errors \
             --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \


### PR DESCRIPTION
## Background

So it turns out the version of curl installed in GHA ubuntu-latest doesn't support `--retry-all-errors` but that's okay because `--retry` already covers the 5XX series of errors that we are seeing.

## How Has This Been Tested

To be tested in #145.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/htvqoWc2vLg3AIsgab/giphy.gif?cid=5a38a5a2unopbkkkkarp21wcr1bagacrtckvq78oysjmg1kl&rid=giphy.gif&ct=g)
