### PR TITLE
Fix SSM, public-active-active

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -55,11 +55,27 @@ module "vpc" {
   }
 }
 
+resource "aws_security_group" "ssm" {
+  description = "The security group of Systems Manager for TFE."
+  name        = "${var.friendly_name_prefix}-tfe"
+  tags        = var.common_tags
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port = 443
+    protocol  = "tcp"
+    to_port   = 443
+
+    cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    description = "Allow the ingress of HTTPS traffic from all private subnets."
+  }
+}
+
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "~> 3.0"
 
-  security_group_ids = [module.vpc.default_security_group_id]
+  security_group_ids = [aws_security_group.ssm.id]
   vpc_id             = module.vpc.vpc_id
   tags               = var.common_tags
 

--- a/modules/vm/outputs.tf
+++ b/modules/vm/outputs.tf
@@ -8,4 +8,6 @@ output "tfe_autoscaling_group" {
   value = aws_autoscaling_group.tfe_asg
 
   description = "The autoscaling group which hosts the TFE EC2 instance(s)."
+  # This output is marked as sensitive to work around a bug in Terraform 0.14
+  sensitive = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -98,4 +98,6 @@ output "tfe_autoscaling_group" {
   value = module.vm.tfe_autoscaling_group
 
   description = "The autoscaling group which hosts the TFE EC2 instance(s)."
+  # This output is marked as sensitive to work around a bug in Terraform 0.14
+  sensitive = true
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -24,6 +24,7 @@ module "public_active_active" {
   external_bootstrap_bucket    = var.external_bootstrap_bucket
   iact_subnet_list             = var.iact_subnet_list
   instance_type                = "m5.xlarge"
+  kms_key_alias                = "test-public-active-active"
   load_balancing_scheme        = "PUBLIC"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs

--- a/tests/public-active-active/versions.tf
+++ b/tests/public-active-active/versions.tf
@@ -1,4 +1,12 @@
 terraform {
+  backend "remote" {
+    organization = "terraform-enterprise-modules-test"
+
+    workspaces {
+      name = "aws-public-active-active"
+    }
+  }
+
   required_version = ">= 0.14"
   required_providers {
     aws = {


### PR DESCRIPTION
## Background

The branch that added support for SSM forgot to include a security group that enabled access between the private subnet and the VPC  endpoints. It also accidentally removed the backend from the public-active-active test case. This branch fixes those issues, and also adds a KMS key alias to public-active-active to ensure uniqueness.


Relates #148


## How Has This Been Tested

Provisioned public-active-active with the SSM role to ensure connectivity was enabled.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/IYIlvuWc21U4g/200.gif?cid=5a38a5a2fznwowesyowxt7v1dozkgokjs59i7mmbzoiza6my&rid=200.gif&ct=g)
