### PR TITLE
Always set outputs, secrets as env vars

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -82,9 +82,11 @@ jobs:
       - name: Wait For TFE
         id: wait-for-tfe
         timeout-minutes: 15
+        env:
+          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
-          while ! curl -sfS --max-time 5 ${{ steps.retrieve-health-check-url.outputs.stdout }}; do sleep 5; done
+          while ! curl -sfS --max-time 5 "$HEALTH_CHECK_URL"; do sleep 5; done
 
       - name: Retrieve TFE URL
         id: retrieve-tfe-url
@@ -100,9 +102,11 @@ jobs:
 
       - name: Retrieve IACT
         id: retrieve-iact
+        env:
+          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
           echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose ${{ steps.retrieve-iact-url.outputs.stdout }} )"
+            curl --fail --retry 5 --verbose "$IACT_URL" )"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -112,9 +116,13 @@ jobs:
 
       - name: Create Admin in TFE
         id: create-admin
+        env:
+          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
+          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
+          IACT: ${{ steps.retrieve-iact.outputs.token }}
         run: |
           echo \
-            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "${{ secrets.TFE_PASSWORD }}"}' \
+            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
           echo "::set-output name=response::$( \
             curl \
@@ -123,12 +131,14 @@ jobs:
             --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \
-            ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}?token=${{ steps.retrieve-iact.outputs.token }})"
+            "$IAU_URL"?token="$IACT")"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
+        env:
+          RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo '${{ steps.create-admin.outputs.response }}' | jq --raw-output '.token')"
+          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test


### PR DESCRIPTION
## Background

GitHub Actions documentation recommends using environment variables to pass secrets between processes [1]. This branch updates the test workflow to consistently do that for secrets and step outputs.

[1]: https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow

## How Has This Been Tested

To be tested after merge.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/WNzeFR3i5iJI52lSnC/200w.gif?cid=5a38a5a2cx86m5bjo8hjmgo0j9mrpid9jbnyfxctyyfp82ad&rid=200w.gif&ct=g)
