### PR TITLE
Patch private_active_active job

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -256,21 +256,11 @@ jobs:
         run: |
           terraform output -no-color -raw health_check_url
 
-      - name: Retrieve Auto Scaling Group name
-        id: retrieve-asg-name
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw tfe_autoscaling_group_name
-
       - name: Retrieve Instance ID
         id: retrieve-instance-id
-        env:
-          ASG_NAME: ${{ steps.retrieve-asg-name.outputs.stdout }}
+        working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
-          echo "::set-output name=id::$( \
-            aws autoscaling describe-auto-scaling-groups \
-              --auto-scaling-group-name "$ASG_NAME" | \
-            jq --raw-output .AutoScalingGroups[0].Instances[0].InstanceId)"
+          terraform output -no-color -raw tfe_instance_id
 
       - name: Write Private SSH Key
         env:
@@ -282,7 +272,7 @@ jobs:
         id: wait-for-tfe
         timeout-minutes: 15
         env:
-          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.id }}
+          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
           ssh \
@@ -315,7 +305,7 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         env:
-          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.id }}
+          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
           ssh \
@@ -339,7 +329,7 @@ jobs:
       - name: Create Admin in TFE
         id: create-admin
         env:
-          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.id }}
+          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
           IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
           IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
@@ -377,7 +367,7 @@ jobs:
         id: run-smoke-test
         working-directory: ${{ env.K6_WORK_DIR_PATH }}
         env:
-          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.id }}
+          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           K6_PATHNAME: "./k6"
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
           TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -287,11 +287,11 @@ jobs:
         run: |
           ssh \
             -i ./ssh-key.pem \
-            -o 'ProxyCommand sh -c "\
-              aws ssm start-session \
+            -o 'ProxyCommand sh -c \
+              "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
-                --parameters \'portNumber=%p\'"' \
+                --parameters \"portNumber=%p\""' \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           echo "Curling \`health_check_url\` for a return status of 200..."
@@ -320,11 +320,11 @@ jobs:
         run: |
           ssh \
             -i ./ssh-key.pem \
-            -o 'ProxyCommand sh -c "\
-              aws ssm start-session \
+            -o 'ProxyCommand sh -c \
+              "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
-                --parameters \'portNumber=%p\'"' \
+                --parameters \"portNumber=%p\""' \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           echo "::set-output name=token::$( \
@@ -346,11 +346,11 @@ jobs:
         run: |
           ssh \
             -i ./ssh-key.pem \
-            -o 'ProxyCommand sh -c "\
-              aws ssm start-session \
+            -o 'ProxyCommand sh -c \
+              "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
-                --parameters \'portNumber=%p\'"' \
+                --parameters \"portNumber=%p\""' \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"INSTANCE_ID"
           echo \
@@ -387,11 +387,11 @@ jobs:
         run: |
           ssh \
             -i ./ssh-key.pem \
-            -o 'ProxyCommand sh -c "\
-              aws ssm start-session \
+            -o 'ProxyCommand sh -c \
+              "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
-                --parameters \'portNumber=%p\'"' \
+                --parameters \"portNumber=%p\""' \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           make smoke-test

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -168,7 +168,7 @@ jobs:
           body: |
             :computer: @hc-team-tfe
 
-            ### Terraform Test Report :newspaper:
+            ### Terraform Public Active/Active Test Report :newspaper:
 
             - Terraform Initialization :gear: `${{ steps.init.outcome }}`
 
@@ -413,7 +413,7 @@ jobs:
           body: |
             :computer: @hc-team-tfe
 
-            ### Terraform Test Report :newspaper:
+            ### Terraform Private Active/Active Test Report :newspaper:
 
             - Terraform Initialization :gear: `${{ steps.init.outcome }}`
 


### PR DESCRIPTION
## Background

This branch patches the test handler based on preliminary results from #154. Specifically, test reports are now qualified with the specific test, quotations in SSH commands are fixed, and the instance ID is assumed to be provided by Terraform outputs.


## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/H6QmaEl2I5LVFp3YWa/giphy.gif?cid=5a38a5a2z17dca9rkdl5nhgpiftpxta5twglobr3okkipqtw&rid=giphy.gif&ct=g)