### PR TITLE
Assume role via configure-aws-credentials action

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -264,13 +264,21 @@ jobs:
           SSH_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_SSH_KEY }}
         run: |
           echo "$SSH_KEY" > ./ssh-key.pem
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+          role-to-assume: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2400
+          role-skip-session-tagging: true
 
       - name: Wait For TFE
         id: wait-for-tfe
         timeout-minutes: 15
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
@@ -304,8 +312,6 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
@@ -330,8 +336,6 @@ jobs:
       - name: Create Admin in TFE
         id: create-admin
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
           IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
@@ -370,8 +374,6 @@ jobs:
         id: run-smoke-test
         working-directory: ${{ env.K6_WORK_DIR_PATH }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           K6_PATHNAME: "./k6"
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"


### PR DESCRIPTION
## Background

Since we need to both authenticate as an IAM user and then assume an IAM role, this branch switches the tests to use aws-actions/configure-aws-credentials for better support of this workflow.


Relates #154


## How Has This Been Tested

This will be tested in #154.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/jrutBd1N7ZhsINAPzs/200.gif?cid=5a38a5a29m1ypq2zi5h6grm736no2tegkzek92cz1srzhyah&rid=200.gif&ct=g)
