### PR TITLE
Add missing region to private_active_active job

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -188,6 +188,7 @@ jobs:
     env:
       WORK_DIR_PATH: ./tests/private-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
+      AWS_DEFAULT_REGION: us-east-2
     steps:
       - name: Create URL to the run output
         id: vars


### PR DESCRIPTION
## Background

The AWS_DEFAULT_REGION variable was inadvertently moved to the defaults for only public_active_active. This branch fixes that mistake.
