### PR TITLE
Wait for EC2 initialization in initial SSH command

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -278,12 +278,12 @@ jobs:
 
       - name: Wait For TFE
         id: wait-for-tfe
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
-          ssh \
+          while ! ssh \
             -i ./ssh-key.pem \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
@@ -291,7 +291,8 @@ jobs:
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
             -f -N -p 22 -D localhost:5000 \
-            ec2-user@"$INSTANCE_ID"
+            ec2-user@"$INSTANCE_ID"; \
+            do sleep 10; done
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -283,7 +283,8 @@ jobs:
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
-          while ! ssh \
+          aws ec2 wait instance-running --instance-id "$INSTANCE_ID"
+          ssh \
             -i ./ssh-key.pem \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
@@ -291,8 +292,7 @@ jobs:
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
             -f -N -p 22 -D localhost:5000 \
-            ec2-user@"$INSTANCE_ID"; \
-            do sleep 10; done
+            ec2-user@"$INSTANCE_ID"
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \


### PR DESCRIPTION
## Background

This branch adds wait logic to the initial SSH over SSM command since EC2 instances take a while to start.

Relates #154

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/pFZTlrO0MV6LoWSDXd/giphy.gif?cid=5a38a5a2iq29wsz9zlaon0mfxd1x3gziv8vmx21j0h3tw6n1&rid=giphy.gif&ct=g)
