### PR TITLE
Check instance status, not running state

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -283,7 +283,7 @@ jobs:
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
-          aws ec2 wait instance-status-ok --instance-id "$INSTANCE_ID"
+          aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
           ssh \
             -i ./ssh-key.pem \
             -o 'ProxyCommand sh -c \

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -283,7 +283,7 @@ jobs:
           INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
-          aws ec2 wait instance-running --instance-id "$INSTANCE_ID"
+          aws ec2 wait instance-status-ok --instance-id "$INSTANCE_ID"
           ssh \
             -i ./ssh-key.pem \
             -o 'ProxyCommand sh -c \


### PR DESCRIPTION
## Background

Previously, `aws ec2 wait instance-running` was introduced to gate the `private_active_active` job before attempting to connect to the private network. However, that was the wrong command to use as an instance that is running is not necessarily ready for connections. This branch replaces that command with `aws ec2 wait instance-status-ok` to wait for all status checks to be green before proceeding.

Relates #159


## How Has This Been Tested

To be tested in #154.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/l0HlAKiRrw4vc5nkk/200.gif?cid=5a38a5a2g63ow9w41adwc73ylcg63jn0ooqp0h7nkssv11t6&rid=200.gif&ct=g)
