### PR TITLE
Enable BatchMode, disable StrictHostKeyChecking

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -286,7 +286,7 @@ jobs:
           aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
           ssh \
             -o 'BatchMode yes' \
-            -o 'StrictHostKeyChecking no' \
+            -o 'StrictHostKeyChecking accept-new' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
@@ -321,7 +321,7 @@ jobs:
         run: |
           ssh \
             -o 'BatchMode yes' \
-            -o 'StrictHostKeyChecking no' \
+            -o 'StrictHostKeyChecking accept-new' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
@@ -349,7 +349,7 @@ jobs:
         run: |
           ssh \
             -o 'BatchMode yes' \
-            -o 'StrictHostKeyChecking no' \
+            -o 'StrictHostKeyChecking accept-new' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
@@ -392,7 +392,7 @@ jobs:
         run: |
           ssh \
             -o 'BatchMode yes' \
-            -o 'StrictHostKeyChecking no' \
+            -o 'StrictHostKeyChecking accept-new' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -285,12 +285,14 @@ jobs:
         run: |
           aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
           ssh \
-            -i ./ssh-key.pem \
+            -o 'BatchMode yes' \
+            -o 'StrictHostKeyChecking no' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
+            -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           echo "Curling \`health_check_url\` for a return status of 200..."
@@ -318,12 +320,14 @@ jobs:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
           ssh \
-            -i ./ssh-key.pem \
+            -o 'BatchMode yes' \
+            -o 'StrictHostKeyChecking no' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
+            -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           echo "::set-output name=token::$( \
@@ -344,12 +348,14 @@ jobs:
           IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
         run: |
           ssh \
-            -i ./ssh-key.pem \
+            -o 'BatchMode yes' \
+            -o 'StrictHostKeyChecking no' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
+            -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"INSTANCE_ID"
           echo \
@@ -385,12 +391,14 @@ jobs:
           https_proxy: socks5://localhost:5000/
         run: |
           ssh \
-            -i ./ssh-key.pem \
+            -o 'BatchMode yes' \
+            -o 'StrictHostKeyChecking no' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
+            -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           make smoke-test


### PR DESCRIPTION
## Background

This branch enables SSH BatchMode and disables StrictHostKeyChecking to support the ssh command running in an automated context. 

Enabling BatchMode disables user interaction behaviour, like password prompts.

Setting StrictHostKeyChecking to accept-new will allow new host keys to be automatically added but not allow for those keys to subsequently change.

## How Has This Been Tested

To be tested in #154.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/l1AsKNjFxbwjXqR0I/giphy.gif?cid=5a38a5a2zvd8aguhyamm6i2vxeu2sodarne85yy7yy82utpj&rid=giphy.gif&ct=g)
