### PR TITLE
Change ssh-key.pem file mode to 0400

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -265,6 +265,7 @@ jobs:
           SSH_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_SSH_KEY }}
         run: |
           echo "$SSH_KEY" > ./ssh-key.pem
+          chmod 0400 ./ssh-key.pem
       
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Background

This branch sets the file mode of the private_active_active SSH key to 0400 as required by SSH.


## How Has This Been Tested

To be tested in #154.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/5SAPlGAS1YnLN9jHua/100.gif?cid=5a38a5a2gcmbrxlmvf7rf96vf2h5pgsvbob2i4wx087rdn7g&rid=100.gif&ct=g)
