### PR TITLE
Use Base64 encoded SSH key for tests

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -358,7 +358,7 @@ jobs:
                 --parameters \"portNumber=%p\""' \
             -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
-            ec2-user@"INSTANCE_ID"
+            ec2-user@"$INSTANCE_ID"
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -294,7 +294,7 @@ jobs:
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
             -i ./ssh-key.pem \
-            -f -N -p 22 -D localhost:5000 \
+            -f -N -p 22 -D localhost:5000 -v \
             ec2-user@"$INSTANCE_ID"
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -262,9 +262,9 @@ jobs:
 
       - name: Write Private SSH Key
         env:
-          SSH_KEY: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_SSH_KEY }}
+          SSH_KEY_BASE64: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_SSH_KEY_BASE64 }}
         run: |
-          echo "$SSH_KEY" > ./ssh-key.pem
+          echo "$SSH_KEY_BASE64" | base64 --decode > ./ssh-key.pem
           chmod 0400 ./ssh-key.pem
       
       - name: Configure AWS Credentials

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           echo "$SSH_KEY_BASE64" | base64 --decode > ./ssh-key.pem
           chmod 0400 ./ssh-key.pem
-      
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -436,4 +436,3 @@ jobs:
             :link: [Action Summary Page][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
-

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -399,7 +399,7 @@ jobs:
                 --target %h \
                 --document-name AWS-StartSSHSession \
                 --parameters \"portNumber=%p\""' \
-            -i ./ssh-key.pem \
+            -i ../../ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
             ec2-user@"$INSTANCE_ID"
           make smoke-test


### PR DESCRIPTION
## Background

This branch attempts to solve the "invalid format" error from ssh by reading a Base64 encoded version of the SSH key. :shrug: It also fixes a couple of SSH-related bugs in other steps.

## How Has This Been Tested

To be tested in #154.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/PjIxLB3QM6wJj7A4UO/200w.gif?cid=5a38a5a2n4pykg3wvhysosgbkf0tza985v0rv5tw3n2uxw13&rid=200w.gif&ct=g)
