### PR TITLE
remove random_pet

### DIFF
--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -1,5 +1,4 @@
 locals {
-  complete_prefix = "${var.prefix}-${random_string.friendly_name.result}"
   http_proxy_port = 3128
 
   common_tags = {

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -4,12 +4,6 @@ provider "aws" {
   }
 }
 
-resource "random_pet" "subdomain" {
-  length    = 2
-  separator = "-"
-  prefix    = var.prefix
-}
-
 resource "random_string" "friendly_name" {
   length  = 4
   upper   = false # Some AWS resources do not accept uppercase characters.
@@ -54,7 +48,7 @@ module "private_tcp_active_active" {
 
   acm_certificate_arn  = var.acm_certificate_arn
   domain_name          = var.domain_name
-  friendly_name_prefix = random_string.friendly_name.id
+  friendly_name_prefix = random_string.friendly_name.result
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
   ami_id                       = data.aws_ami.rhel.id

--- a/tests/private-tcp-active-active/outputs.tf
+++ b/tests/private-tcp-active-active/outputs.tf
@@ -40,4 +40,6 @@ output "tfe_autoscaling_group_name" {
   value = module.private_tcp_active_active.tfe_autoscaling_group.name
 
   description = "The name of the autoscaling group which hosts the TFE EC2 instance(s)."
+  # This output is marked as sensitive to work around a bug in Terraform 0.14
+  sensitive = true
 }

--- a/tests/private-tcp-active-active/proxy.tf
+++ b/tests/private-tcp-active-active/proxy.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "proxy" {
-  name   = "${local.complete_prefix}-sg-proxy-allow"
+  name   = "${random_string.friendly_name.result}-sg-proxy-allow"
   vpc_id = module.private_tcp_active_active.network_id
 
   tags = merge(
-    { Name = "${local.complete_prefix}-sg-proxy-allow" },
+    { Name = "${random_string.friendly_name.result}-sg-proxy-allow" },
     local.common_tags
   )
 }


### PR DESCRIPTION
## Background

This was [broken](https://github.com/hashicorp/terraform-aws-terraform-enterprise/runs/2668446706?check_suite_focus=true#step:8:13) because it didn't have a variable for `prefix`, but it wasn't necessary, so I removed the config that required it.

[Asana Task](https://app.asana.com/0/1181500399442529/1200360153490753/f)

## How Has This Been Tested

I ran `terraform validate` and `terraform fmt` locally on this test example.

## This PR makes me feel

![fix it](https://media.giphy.com/media/l49JWMZfuyqbikTDi/giphy.gif)
