### PR TITLE
Replace local cert with bucket object

### DIFF
--- a/tests/private-tcp-active-active/certificates.tf
+++ b/tests/private-tcp-active-active/certificates.tf
@@ -1,30 +1,9 @@
-resource "tls_private_key" "ca" {
-  algorithm = "RSA"
+data "aws_s3_bucket_object" "proxy_certificate" {
+  bucket = var.external_bootstrap_bucket
+  key    = var.proxy_certificate_bucket_object_key
 }
 
-resource "tls_self_signed_cert" "ca" {
-  key_algorithm         = tls_private_key.ca.algorithm
-  private_key_pem       = tls_private_key.ca.private_key_pem
-  validity_period_hours = 24 * 30 * 6
-
-  subject {
-    organization = "HashiCorp (NonTrusted)"
-    common_name  = "HashiCorp (NonTrusted) Private Certificate Authority"
-    country      = "US"
-  }
-
-  is_ca_certificate = true
-
-  allowed_uses = [
-    "cert_signing",
-    "key_encipherment",
-    "digital_signature"
-  ]
-}
-
-resource "local_file" "ca" {
-  filename = "${path.module}/files/mitmproxy.pem"
-
-  content         = tls_self_signed_cert.ca.cert_pem
-  file_permission = "0644"
+data "aws_s3_bucket_object" "proxy_private_key" {
+  bucket = var.external_bootstrap_bucket
+  key    = var.proxy_private_key_bucket_object_key
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -18,7 +18,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.4_HVM-*-x86_64-*-Hourly2-GP2"]
+    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
   }
 
   filter {

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -76,11 +76,3 @@ module "private_tcp_active_active" {
 
   common_tags = local.common_tags
 }
-
-data "aws_instances" "main" {
-  instance_tags = local.common_tags
-
-  depends_on = [
-    module.private_tcp_active_active
-  ]
-}

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -67,8 +67,7 @@ module "private_tcp_active_active" {
   network_public_subnets       = var.network_public_subnets
   node_count                   = 2
   proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
-  proxy_cert_bundle_filepath   = local_file.ca.filename
-  proxy_cert_bundle_name       = "mitmproxy"
+  proxy_cert_bundle_name       = data.aws_s3_bucket_object.proxy_certificate.key
   redis_encryption_at_rest     = true
   redis_encryption_in_transit  = true
   redis_require_password       = true

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -58,7 +58,6 @@ module "private_tcp_active_active" {
   iact_subnet_list             = ["0.0.0.0/0"]
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   instance_type                = "m5.8xlarge"
-  key_name                     = var.key_name
   kms_key_alias                = "test-private-tcp-active-active"
   load_balancing_scheme        = "PRIVATE_TCP"
   network_id                   = var.network_id

--- a/tests/private-tcp-active-active/outputs.tf
+++ b/tests/private-tcp-active-active/outputs.tf
@@ -31,9 +31,9 @@ output "initial_admin_user_url" {
 }
 
 output "tfe_instance_id" {
-  value = data.aws_instances.main.ids[0]
+  value = aws_instance.proxy.id
 
-  description = "The ID of a TFE EC2 instance."
+  description = "The ID of the proxy EC2 instance."
 }
 
 output "tfe_autoscaling_group_name" {

--- a/tests/private-tcp-active-active/proxy.tf
+++ b/tests/private-tcp-active-active/proxy.tf
@@ -77,6 +77,7 @@ resource "aws_instance" "proxy" {
   instance_type = "m4.xlarge"
 
   iam_instance_profile = aws_iam_instance_profile.proxy.name
+  key_name             = var.key_name
   subnet_id            = module.private_tcp_active_active.private_subnet_ids[0]
 
   vpc_security_group_ids = [

--- a/tests/private-tcp-active-active/proxy.tf
+++ b/tests/private-tcp-active-active/proxy.tf
@@ -41,11 +41,43 @@ resource "aws_security_group_rule" "proxy_egress" {
   security_group_id = aws_security_group.proxy.id
 }
 
+resource "aws_iam_instance_profile" "proxy" {
+  name_prefix = "${random_string.friendly_name.result}-proxy"
+  role        = aws_iam_role.instance_role.name
+}
+
+resource "aws_iam_role" "instance_role" {
+  name_prefix        = "${random_string.friendly_name.result}-proxy"
+  assume_role_policy = data.aws_iam_policy_document.instance_role.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "instance_role" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 resource "aws_instance" "proxy" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = "m4.xlarge"
 
-  subnet_id = module.private_tcp_active_active.public_subnet_ids[0]
+  iam_instance_profile = aws_iam_instance_profile.proxy.name
+  subnet_id            = module.private_tcp_active_active.private_subnet_ids[0]
 
   vpc_security_group_ids = [
     aws_security_group.proxy.id

--- a/tests/private-tcp-active-active/proxy.tf
+++ b/tests/private-tcp-active-active/proxy.tf
@@ -55,9 +55,9 @@ resource "aws_instance" "proxy" {
     templatefile(
       "${path.module}/templates/mitmproxy.sh.tpl",
       {
-        certificate     = tls_self_signed_cert.ca.cert_pem
+        certificate     = data.aws_s3_bucket_object.proxy_certificate.body
         http_proxy_port = local.http_proxy_port
-        private_key     = tls_private_key.ca.private_key_pem
+        private_key     = data.aws_s3_bucket_object.proxy_private_key.body
       }
     )
   )

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -43,3 +43,13 @@ variable "key_name" {
   description = "The name of the key pair to be used for SSH access to the EC2 instance(s)."
   type        = string
 }
+
+variable "proxy_certificate_bucket_object_key" {
+  description = "The key of the proxy certificate bucket object."
+  type        = string
+}
+
+variable "proxy_private_key_bucket_object_key" {
+  description = "The key of the proxy private key bucket object."
+  type        = string
+}

--- a/tests/private-tcp-active-active/versions.tf
+++ b/tests/private-tcp-active-active/versions.tf
@@ -13,17 +13,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.15"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 2.1"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## Background

This branch adjusts the private-tcp-active-active job to use an existing proxy certificate found in the external bootstrap bucket.

## How Has This Been Tested

To be tested here!

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/kqu0JnieiuhGw/200w.gif?cid=5a38a5a2al6n1f5l1j6nhup7mzfcz29hf4kz2j25rnj9q9e5&rid=200w.gif&ct=g)
