### PR TITLE
Added a wait for curls and insecure flags

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -515,6 +515,8 @@ jobs:
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \
+            --insecure \
+            --connect-timeout 5 \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \
             $HEALTH_CHECK_URL; \
             do sleep 5; done
@@ -537,7 +539,10 @@ jobs:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
           echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL" )"
+            curl --fail --retry 5 --verbose \
+            --insecure \
+            --connect-timeout 5 \
+            --proxy socks5://localhost:5000 "$IACT_URL" )"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -557,6 +562,8 @@ jobs:
             > ./payload.json
           echo "::set-output name=response::$( \
             curl \
+            --insecure \
+            --connect-timeout 5 \
             --fail \
             --retry 5 \
             --verbose \


### PR DESCRIPTION
## Background

For the tcp test scenario, I added some waits for the curl commands as well as an insecure flag since we're using self-signed certs for the proxy.

[Asana](https://app.asana.com/0/1181500399442529/1200106415052873/f)

## This PR makes me feel

![wait](https://media.giphy.com/media/JQudLDYB2ATMLbuNDO/giphy.gif)
