### PR TITLE
Skip TLS verify for private_tcp_active_active smoke test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -587,6 +587,7 @@ jobs:
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
           TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
           TFE_EMAIL: tf-onprem-team@hashicorp.com
+          TFE_SKIP_TLS_VERIFY: "true"
           http_proxy: socks5://localhost:5000/
           https_proxy: socks5://localhost:5000/
         run: |
@@ -624,4 +625,3 @@ jobs:
             :link: [Action Summary Page][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
-            


### PR DESCRIPTION
## Background

This branch disables TLS verification for the smoke tests of the private_tcp_active_active job as the deployment uses a self-signed certificate.

## How Has This Been Tested

To be tested in #168.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/3orieZPbT6w4JQsYSY/giphy.gif?cid=5a38a5a25xubusxjsyi5jlxslrcato8b8bbcch3z4nn4d536&rid=giphy.gif&ct=g)
