### PR TITLE
Add ServerAliveInterval to SOCKS5 Proxy

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -498,6 +498,8 @@ jobs:
           ssh \
             -o 'BatchMode yes' \
             -o 'StrictHostKeyChecking accept-new' \
+            -o 'ServerAliveInterval 5' \
+            -o 'ServerAliveCountMax 3' \
             -o 'ProxyCommand sh -c \
               "aws ssm start-session \
                 --target %h \


### PR DESCRIPTION
## Background

The SOCKS5 proxy of the private_tcp_active_active job is acting very flakey. This branch adds ServerAliveInterval and ServerAliveCount to the underlying `ssh` command in an attempt to keep things running smoothly.

## How Has This Been Tested

To be tested in #168.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/gd09Y2Ptu7gsiPVUrv/200.gif?cid=5a38a5a21nfpozdrhcjuo7d2zocg1tghr4flu73pnsvcrzlo&rid=200.gif&ct=g)
