### PR TITLE
Add arguments to test slash command

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   public_active_active:
     name: Run tf-test on Public Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, "all") || contains(github.event.client_payload.slash_command.args.unnamed.all, "public-active-active") }}
     runs-on: ubuntu-latest
     env:
       WORK_DIR_PATH: ./tests/public-active-active
@@ -184,6 +185,7 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
   private_active_active:
     name: Run tf-test on Private Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, "all") || contains(github.event.client_payload.slash_command.args.unnamed.all, "private-active-active") }}
     runs-on: ubuntu-latest
     env:
       WORK_DIR_PATH: ./tests/private-active-active
@@ -402,6 +404,7 @@ jobs:
 
   private_tcp_active_active:
     name: Run tf-test on Private TCP Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, "all") || contains(github.event.client_payload.slash_command.args.unnamed.all, "private-tcp-active-active") }}
     runs-on: ubuntu-latest
     env:
       WORK_DIR_PATH: ./tests/private-tcp-active-active

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Terraform Destroy
         id: destroy
+        if: ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' }}
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform destroy -auto-approve -input=false -no-color
 
@@ -371,6 +372,7 @@ jobs:
 
       - name: Terraform Destroy
         id: destroy
+        if: ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' }}
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform destroy -auto-approve -input=false -no-color
 
@@ -600,6 +602,7 @@ jobs:
 
       - name: Terraform Destroy
         id: destroy
+        if: ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' }}
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform destroy -auto-approve -input=false -no-color
 


### PR DESCRIPTION
## Background

This branch adds arguments to the test slash command:

- `all` will execute all test cases
- unnamed arguments like `public-active-active` will select individual test cases to be executed if they match a corresponding job name defined in `handler-test.yml`
- `destroy=false` will disable the execution of `terraform destroy` for all test cases

## How Has This Been Tested

To be tested in #168.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/6utVfLUy9FmxBI63IP/200w.gif?cid=5a38a5a2s51y98nnyf0yv1p2apvi41bswudt5uqee1dtyt9u&rid=200w.gif&ct=g)
