### PR TITLE
Use single quotation marks in `if` cases

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   public_active_active:
     name: Run tf-test on Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, "all") || contains(github.event.client_payload.slash_command.args.unnamed.all, "public-active-active") }}
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
     runs-on: ubuntu-latest
     env:
       WORK_DIR_PATH: ./tests/public-active-active
@@ -186,7 +186,7 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
   private_active_active:
     name: Run tf-test on Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, "all") || contains(github.event.client_payload.slash_command.args.unnamed.all, "private-active-active") }}
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
     runs-on: ubuntu-latest
     env:
       WORK_DIR_PATH: ./tests/private-active-active
@@ -406,7 +406,7 @@ jobs:
 
   private_tcp_active_active:
     name: Run tf-test on Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, "all") || contains(github.event.client_payload.slash_command.args.unnamed.all, "private-tcp-active-active") }}
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}
     runs-on: ubuntu-latest
     env:
       WORK_DIR_PATH: ./tests/private-tcp-active-active


### PR DESCRIPTION
## Background

This branch fixes the quotation marks used in the literals used to evaluate slash command arguments.


## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/2A4A9kI7YFXC789O7A/giphy.gif?cid=5a38a5a2be81e3ejbi24okl03927ekjg3eoh2byhfa8ne6ym&rid=giphy.gif&ct=g)
