### PR TITLE
Fix username of SSH connection

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -512,7 +512,7 @@ jobs:
                 --parameters \"portNumber=%p\""' \
             -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
-            ec2-user@"$INSTANCE_ID"
+            ubuntu@"$INSTANCE_ID"
 
       - name: Wait For TFE
         id: wait-for-tfe


### PR DESCRIPTION
## Background

This branch fixes the username of the SSH connection in private_tcp_active_active, as the proxy is running Ubuntu.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/THHeqBcZnprb9zJNnO/giphy.gif?cid=5a38a5a2t2ucfv78umu5i2qosruk7ji2npwuu7znyc2w4w7t&rid=giphy.gif&ct=g)
