### PR TITLE
Use multiple tokens to reduce scope of permissions

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -14,9 +14,14 @@ jobs:
 
     name: Run terraform fmt
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
@@ -31,9 +36,14 @@ jobs:
 
     name: Run terraform-lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false
 
     - name: Setup Terraform Lint
       uses: terraform-linters/setup-tflint@v1

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # The `public_repo` scope is required by this token to create repository_dispatch and workflow_dispatch
           # events on public repositories. The default GITHUB_TOKEN does not support the `public_repo` scope.
-          token: ${{ secrets.GITHUB_DISPATCH_TOKEN }}
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           commands: |
             test

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -9,11 +9,13 @@ jobs:
   slash_command_dispatch:
     name: Slash Command Dispatcher
     runs-on: ubuntu-latest
+    permissions:
+      pull-request: write
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.PAT }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
           commands: |
             test
             help

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v2
         with:
+          # The `public_repo` scope is required by this token to create repository_dispatch and workflow_dispatch
+          # events on public repositories. The default GITHUB_TOKEN does not support the `public_repo` scope.
+          token: ${{ secrets.GITHUB_DISPATCH_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           commands: |
             test

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -9,11 +9,13 @@ jobs:
   help:
     name: Run help
     runs-on: ubuntu-latest
+    permissions:
+      pull-request: write
     steps:
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -21,6 +21,6 @@ jobs:
           body: |
             > Command | Description
             > --- | ---
-            > /test | Run the Terraform test workflow on the modules in the tests/ directory
+            > /test <all|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory. Unnamed arguments can be "all" to run all test cases or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes.
             > /help | Shows this help message
           reaction-type: hooray

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -23,4 +23,4 @@ jobs:
             > --- | ---
             > /test <all|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory. Unnamed arguments can be "all" to run all test cases or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes.
             > /help | Shows this help message
-          reaction-type: hooray
+          reaction-type: confused

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-request: write
     env:
       WORK_DIR_PATH: ./tests/public-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -167,7 +168,7 @@ jobs:
         if: ${{ always() }}
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
@@ -194,6 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-request: write
     env:
       WORK_DIR_PATH: ./tests/private-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -390,7 +392,7 @@ jobs:
         if: ${{ always() }}
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
@@ -418,6 +420,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-request: write
     env:
       WORK_DIR_PATH: ./tests/private-tcp-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -624,7 +627,7 @@ jobs:
         if: ${{ always() }}
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -10,6 +10,8 @@ jobs:
     name: Run tf-test on Public Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       WORK_DIR_PATH: ./tests/public-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -25,6 +27,8 @@ jobs:
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       # Checkout the hashicorp/tfe-load-test repository
       - name: Checkout TFE Load Test
@@ -188,6 +192,8 @@ jobs:
     name: Run tf-test on Private Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       WORK_DIR_PATH: ./tests/private-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -203,6 +209,8 @@ jobs:
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       # Checkout the hashicorp/tfe-load-test repository
       - name: Checkout TFE Load Test
@@ -408,6 +416,8 @@ jobs:
     name: Run tf-test on Private TCP Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       WORK_DIR_PATH: ./tests/private-tcp-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -423,6 +433,8 @@ jobs:
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       # Checkout the hashicorp/tfe-load-test repository
       - name: Checkout TFE Load Test

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -38,7 +38,8 @@ jobs:
           ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
 
       - name: Install required tools
         working-directory: ${{ env.K6_WORK_DIR_PATH }}
@@ -221,7 +222,8 @@ jobs:
           ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
 
       - name: Install required tools
         working-directory: ${{ env.K6_WORK_DIR_PATH }}
@@ -446,7 +448,8 @@ jobs:
           ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
 
       - name: Install required tools
         working-directory: ${{ env.K6_WORK_DIR_PATH }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -38,7 +38,7 @@ jobs:
           ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
-          token: ${{ secrets.GITHUB_TFE_LOAD_TEST_TOKEN }}
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
           persist-credentials: false
 
       - name: Install required tools
@@ -222,7 +222,7 @@ jobs:
           ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
-          token: ${{ secrets.GITHUB_TFE_LOAD_TEST_TOKEN }}
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
           persist-credentials: false
 
       - name: Install required tools
@@ -448,7 +448,7 @@ jobs:
           ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
-          token: ${{ secrets.GITHUB_TFE_LOAD_TEST_TOKEN }}
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
           persist-credentials: false
 
       - name: Install required tools


### PR DESCRIPTION
## Background

This branch updates the GitHub Actions workflows to rely on multiple, minimally privileged tokens in order to minimize the scope of available permissions for any particular job.


[Asana task](https://app.asana.com/0/1181500399442529/1200329454162744/f)

To do:

- [x] set default permissions for GITHUB_TOKEN to read only
- [x] create GH_DISPATCH_TOKEN with `public_repo` scope
- [x] create GH_TFE_LOAD_TEST_TOKEN with `repo` scope
- [x] remove PAT

## How Has This Been Tested

To be tested and iterated on post-merge.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/L0O7hughPslHvVx9A4/giphy.gif?cid=5a38a5a2hc3n2cr9i1kuobqc48zr11o20r93pnd8fyzhfihp&rid=giphy.gif&ct=g)
