### PR TITLE
Fix name of pull-requests permission

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -10,7 +10,7 @@ jobs:
     name: Slash Command Dispatcher
     runs-on: ubuntu-latest
     permissions:
-      pull-request: write
+      pull-requests: write
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v2

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run help
     runs-on: ubuntu-latest
     permissions:
-      pull-request: write
+      pull-requests: write
     steps:
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-request: write
+      pull-requests: write
     env:
       WORK_DIR_PATH: ./tests/public-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-request: write
+      pull-requests: write
     env:
       WORK_DIR_PATH: ./tests/private-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test
@@ -422,7 +422,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-request: write
+      pull-requests: write
     env:
       WORK_DIR_PATH: ./tests/private-tcp-active-active
       K6_WORK_DIR_PATH: ./tests/tfe-load-test


### PR DESCRIPTION
## Background

This branch fixes the name of the `pull-requests` permission in the Actions workflow files.


Relates #175



## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/51UpoMnNqaBRSfl7cy/200w.gif?cid=5a38a5a2e64mfc6ont3j6t0o1fvmdlc3cpw3ai5743ig8jyn&rid=200w.gif&ct=g)
