### PR TITLE
Fix help table layout

### DIFF
--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -19,8 +19,8 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            > Command | Description
-            > --- | ---
-            > /test <all|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory. Unnamed arguments can be "all" to run all test cases or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes.
-            > /help | Shows this help message
+            > | Command | Description |
+            > | ------- | ----------- |
+            > | /test <all\|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory. Unnamed arguments can be "all" to run all test cases or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes. |
+            > | /help | Shows this help message |
           reaction-type: confused


### PR DESCRIPTION
## Background

This branch fixes the /help table layout. It will render as follows:

> | Command | Description |
> | ------- | ----------- |
> | /test <all\|test case name...> [destroy=false] | Run the Terraform test workflow on the modules in the tests/ directory. Unnamed arguments can be "all" to run all test cases or specific test case names to only run selected cases. The named argument "destroy=false" will disable the destruction of test infrastructure for debugging purposes. |
> | /help | Shows this help message |


Relates #175


## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/gw3MYmhxEv8T52ow/giphy.gif?cid=5a38a5a2hyczxqfxoxa41ulnj8g2nishwi1tp3nr5fto8jnc&rid=giphy.gif&ct=g)
