### PR TITLE
ami example

### DIFF
--- a/examples/existing-image/README.md
+++ b/examples/existing-image/README.md
@@ -1,0 +1,61 @@
+# EXAMPLE: Using this module to deploy with a custom image
+
+## About This Example
+
+This example functions as a reference for how to use this module to install Terraform Enterprise with a custom image (AMI) in AWS. This module has been verified to be functional with Ubuntu 20.04 LTS and RHEL 7.x based images.
+
+## Module Prerequisites
+
+As with the main version of this module, this example assumes the following resources already exist:
+
+- Valid DNS Zone managed in Route53
+- Valid AWS ACM certificate
+- Valid TFE license
+
+## How to Use This Module
+
+- Ensure account meets module pre-requisites from above.
+- Create a Terraform configuration that pulls in this module and specifies values
+  of the required variables (you may do this in a `terraform.tfvars` file):
+
+```hcl
+provider "aws" {}
+
+data "aws_ami" "existing" {
+  owners      = var.ami_owners
+  most_recent = var.ami_most_recent
+
+  filter {
+    name   = var.ami_filter_name
+    values = [var.ami_filter_value]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+module "existing_image_example" {
+  source = "../../"
+
+  acm_certificate_arn  = var.acm_certificate_arn
+  domain_name          = var.domain_name
+  friendly_name_prefix = var.friendly_name_prefix
+  tfe_subdomain        = var.tfe_subdomain
+  tfe_license_name     = var.tfe_license_name
+  tfe_license_filepath = var.tfe_license_filepath
+
+  ami_id                = data.aws_ami.existing.id
+  iact_subnet_list      = var.iact_subnet_list
+  load_balancing_scheme = var.load_balancing_scheme
+
+  common_tags = var.common_tags
+}
+```
+
+- Run `terraform init` and `terraform apply`
+
+### ami_id
+
+In the `ami_id` data source, you will notice that this example filters on three criteria, a unique key/value pair, the virtualization type, and whether or not to use the latest image in which this search results. Because it is important that Terraform is only able to find one AMI based on the search of this [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami), you may decide to add more filters in order to narrow down your search. Otherwise, you may also decide to enter the `ami_id` directly, instead of searching for it. To do this, simply replace "data.aws_ami.existing.id" as the value of the `ami_id` variable with the specific AMI ID that you wish to use.

--- a/examples/existing-image/README.md
+++ b/examples/existing-image/README.md
@@ -58,4 +58,8 @@ module "existing_image_example" {
 
 ### ami_id
 
-In the `ami_id` data source, you will notice that this example filters on three criteria, a unique key/value pair, the virtualization type, and whether or not to use the latest image in which this search results. Because it is important that Terraform is only able to find one AMI based on the search of this [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami), you may decide to add more filters in order to narrow down your search. Otherwise, you may also decide to enter the `ami_id` directly, instead of searching for it. To do this, simply replace "data.aws_ami.existing.id" as the value of the `ami_id` variable with the specific AMI ID that you wish to use.
+This example will either use the `ami_id` directly, or you may use a data source to filter on the specific AMI to use.
+
+In the `ami_id` data source, you will notice that this example filters on three criteria, a unique key/value pair, the virtualization type, and whether or not to use the latest image in which this search results. Because it is important that Terraform is only able to find one AMI based on the search of this [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami), you may decide to add more filters in order to narrow down your search.
+
+Otherwise, you may decide to provide the `ami_id` variable directly, instead of using the data source. To do this, simply provide a value for the `ami_id` variable with the specific AMI ID that you wish to use. If you choose to do this, you do not need to provide values for the other variables that begin with `ami_`.

--- a/examples/existing-image/README.md
+++ b/examples/existing-image/README.md
@@ -25,8 +25,6 @@ root module, which defaults to a node count of 2, creating an Active/Active conf
   of the required variables (you may do this in a `terraform.tfvars` file):
 
 ```hcl
-provider "aws" {}
-
 locals {
   ami_search = var.ami_id == null ? true : false
   ami_id     = local.ami_search ? data.aws_ami.existing[0].id : var.ami_id

--- a/examples/existing-image/README.md
+++ b/examples/existing-image/README.md
@@ -1,12 +1,14 @@
-# EXAMPLE: Using this module to deploy with a custom image
+# EXAMPLE: Deploying Terraform Enterprise in Active/Active mode with a custom image
 
 ## About This Example
 
-This example functions as a reference for how to use this module to install Terraform Enterprise with a custom image (AMI) in AWS. This module has been verified to be functional with Ubuntu 20.04 LTS and RHEL 7.x based images.
+This example functions as a reference for how to use this module to install 
+Terraform Enterprise with a custom image (AMI) in AWS.
 
 ## Module Prerequisites
 
-As with the main version of this module, this example assumes the following resources already exist:
+As with the main version of this module, this example assumes the following
+resources already exist:
 
 - Valid DNS Zone managed in Route53
 - Valid AWS ACM certificate
@@ -14,6 +16,10 @@ As with the main version of this module, this example assumes the following reso
 
 ## How to Use This Module
 
+Refer to the root module's instructions for [setup instructions](../../README.md#How-to-Use-This-Module).
+
+- Any variables not defined in this example will use the default values of the
+root module, which defaults to a node count of 2, creating an Active/Active configuration.
 - Ensure account meets module pre-requisites from above.
 - Create a Terraform configuration that pulls in this module and specifies values
   of the required variables (you may do this in a `terraform.tfvars` file):
@@ -53,7 +59,7 @@ module "existing_image_example" {
   tfe_license_name     = var.tfe_license_name
   tfe_license_filepath = var.tfe_license_filepath
 
-  ami_id                = data.aws_ami.existing.id
+  ami_id                = local.ami_id
   iact_subnet_list      = var.iact_subnet_list
   load_balancing_scheme = var.load_balancing_scheme
 
@@ -61,12 +67,48 @@ module "existing_image_example" {
 }
 ```
 
-- Run `terraform init` and `terraform apply`
+With authentication configured, run `terraform init` and `terraform apply` to provision
+the example infrastructure.
+
+
+## Variable Input
+
+The variable inputs described in this document serve as a reference configuration for this specific example. The root module provides many other optional variable inputs.
+
+### Inputs For This Example
+
+| Name | Description | Type | Example Value |
+|------|-------------|------| ------------- |
+| `acm_certificate_arn` | ACM certificate ARN to use with load balancer | string | `arn:aws:acm:us-east-2:123456:certificate/123abc`
+| `domain_name` | Name of existing DNS Zone in which a record set will be created | string | `example.com` |
+| `friendly_name_prefix` | Name prefix used for resources | string | `somename` |
+| `tfe_subdomain` | Desired DNS record subdomain | string | `tfe` |
+| `tfe_license_name` | The name to use when copying the TFE license file to the EC2 instance. | string | `license.rli` |
+| `tfe_license_filepath` | The absolute path to the TFE license file on the system running Terraform. | string | `Users/yourname/license.rli` |
+| `common_tags` | Map of tags to use for resources | map(string) | `{ Owner = "Your Name" }` |
+| `iact_subnet_list` | A list of CIDR masks that configure the ability to retrieve the IACT from outside the host. | list(string) | `["0.0.0.0/0"]` |
+| `load_balancing_scheme` | Load Balancing Scheme. Supported values are: "PRIVATE"; "PRIVATE_TCP"; "PUBLIC". | string | `PUBLIC` |
+| `ami_id` | AMI ID of the custom image to use for TFE instances. If this value is provided, you do not need any of the following ami variable values. | string | `ami-12345` |
+| `ami_owners` | List of AMI owners to limit search. (Not needed if providing ami_id value.) | list(string) | `["self"]` |
+| `ami_filter_name` | The name of a key off of which to filter with a key/value pair. (Not needed if providing ami_id value.) | string | `"tag:Distro"` |
+| `ami_filter_value` | The value off of which to filter with a key/value pair. (Not needed if providing ami_id value.) | string | `"Ubuntu"` |
+| `ami_most_recent` | If more than one result is returned, use the most recent AMI. (Not needed if providing ami_id value.) | bool | `true` |
 
 ### ami_id
 
-This example will either use the `ami_id` directly, or you may use a data source to filter on the specific AMI to use.
+The base image used for the custom image should be Ubuntu or RHEL to work with the root
+module as-is.
 
-In the `ami_id` data source, you will notice that this example filters on three criteria, a unique key/value pair, the virtualization type, and whether or not to use the latest image in which this search results. Because it is important that Terraform is only able to find one AMI based on the search of this [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami), you may decide to add more filters in order to narrow down your search.
+This example will either use the `ami_id` directly, or you may use a data source to filter
+on the specific AMI to use.
 
-Otherwise, you may decide to provide the `ami_id` variable directly, instead of using the data source. To do this, simply provide a value for the `ami_id` variable with the specific AMI ID that you wish to use. If you choose to do this, you do not need to provide values for the other variables that begin with `ami_`.
+In the `ami_id` data source, you will notice that this example filters on three criteria, a
+unique key/value pair, the virtualization type, and whether or not to use the latest image
+in which this search results. Because it is important that Terraform is only able to find
+one AMI based on the search of this [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami),
+you may decide to add more filters in order to narrow down your search.
+
+Otherwise, you may decide to provide the `ami_id` variable directly, instead of using the
+data source. To do this, simply provide a value for the `ami_id` variable with the specific
+AMI ID that you wish to use. If you choose to do this, you do not need to provide values for
+the other variables that begin with `ami_`.

--- a/examples/existing-image/README.md
+++ b/examples/existing-image/README.md
@@ -21,7 +21,14 @@ As with the main version of this module, this example assumes the following reso
 ```hcl
 provider "aws" {}
 
+locals {
+  ami_search = var.ami_id == null ? true : false
+  ami_id     = local.ami_search ? data.aws_ami.existing[0].id : var.ami_id
+}
+
 data "aws_ami" "existing" {
+  count = local.ami_search ? 1 : 0
+
   owners      = var.ami_owners
   most_recent = var.ami_most_recent
 

--- a/examples/existing-image/main.tf
+++ b/examples/existing-image/main.tf
@@ -1,6 +1,14 @@
 provider "aws" {}
 
+locals {
+  ami_search = var.ami_id == null ? true : false
+  ami_id     = local.ami_search ? data.aws_ami.existing[0].id : var.ami_id
+}
+
+
 data "aws_ami" "existing" {
+  count = local.ami_search ? 1 : 0
+
   owners      = var.ami_owners
   most_recent = var.ami_most_recent
 
@@ -25,7 +33,7 @@ module "existing_image_example" {
   tfe_license_name     = var.tfe_license_name
   tfe_license_filepath = var.tfe_license_filepath
 
-  ami_id                = data.aws_ami.existing.id
+  ami_id                = local.ami_id
   iact_subnet_list      = var.iact_subnet_list
   load_balancing_scheme = var.load_balancing_scheme
 

--- a/examples/existing-image/main.tf
+++ b/examples/existing-image/main.tf
@@ -1,5 +1,3 @@
-provider "aws" {}
-
 locals {
   ami_search = var.ami_id == null ? true : false
   ami_id     = local.ami_search ? data.aws_ami.existing[0].id : var.ami_id

--- a/examples/existing-image/main.tf
+++ b/examples/existing-image/main.tf
@@ -5,7 +5,6 @@ locals {
   ami_id     = local.ami_search ? data.aws_ami.existing[0].id : var.ami_id
 }
 
-
 data "aws_ami" "existing" {
   count = local.ami_search ? 1 : 0
 

--- a/examples/existing-image/main.tf
+++ b/examples/existing-image/main.tf
@@ -1,0 +1,33 @@
+provider "aws" {}
+
+data "aws_ami" "existing" {
+  owners      = var.ami_owners
+  most_recent = var.ami_most_recent
+
+  filter {
+    name   = var.ami_filter_name
+    values = [var.ami_filter_value]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+module "existing_image_example" {
+  source = "../../"
+
+  acm_certificate_arn  = var.acm_certificate_arn
+  domain_name          = var.domain_name
+  friendly_name_prefix = var.friendly_name_prefix
+  tfe_subdomain        = var.tfe_subdomain
+  tfe_license_name     = var.tfe_license_name
+  tfe_license_filepath = var.tfe_license_filepath
+
+  ami_id                = data.aws_ami.existing.id
+  iact_subnet_list      = var.iact_subnet_list
+  load_balancing_scheme = var.load_balancing_scheme
+
+  common_tags = var.common_tags
+}

--- a/examples/existing-image/outputs.tf
+++ b/examples/existing-image/outputs.tf
@@ -1,0 +1,19 @@
+output "tfe_url" {
+  value       = module.existing_image_example.tfe_url
+  description = "The URL to the TFE application."
+}
+
+output "health_check_url" {
+  value       = "${module.existing_image_example.tfe_url}/_health_check"
+  description = "The URL with path to access the TFE instance health check."
+}
+
+output "iact_url" {
+  value       = "${module.existing_image_example.tfe_url}/admin/retrieve-iact"
+  description = "The URL with path to access the TFE instance Retrieve IACT."
+}
+
+output "initial_admin_user_url" {
+  value       = "${module.existing_image_example.tfe_url}/admin/initial-admin-user"
+  description = "The URL with path to access the TFE instance Initial Admin User."
+}

--- a/examples/existing-image/variables.tf
+++ b/examples/existing-image/variables.tf
@@ -60,25 +60,32 @@ variable "load_balancing_scheme" {
 # AMI
 # ---
 
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = "AMI ID of the custom image to use for TFE instances. If this value is provided, you do not need any of the following ami variable values."
+}
+
 variable "ami_owners" {
   type        = list(string)
   default     = ["self"]
-  description = "List of AMI owners to limit search."
+  description = "List of AMI owners to limit search. (Not needed if providing ami_id value.)"
 }
 
 variable "ami_filter_name" {
   type        = string
-  default     = "tag"
-  description = "The name of a key off of which to filter with a key/value pair. Example: \"tag:Distro\""
+  default     = null
+  description = "The name of a key off of which to filter with a key/value pair. Example: \"tag:Distro\" (Not needed if providing ami_id value.)"
 }
 
 variable "ami_filter_value" {
   type        = string
-  description = "The value off of which to filter with a key/value pair. Example: \"Ubuntu\""
+  default     = null
+  description = "The value off of which to filter with a key/value pair. Example: \"Ubuntu\" (Not needed if providing ami_id value.)"
 }
 
 variable "ami_most_recent" {
   type        = bool
   default     = true
-  description = "If more than one result is returned, use the most recent AMI."
+  description = "If more than one result is returned, use the most recent AMI. (Not needed if providing ami_id value.)"
 }

--- a/examples/existing-image/variables.tf
+++ b/examples/existing-image/variables.tf
@@ -1,0 +1,84 @@
+# -------
+# General
+# -------
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN to use with load balancer"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain to create Terraform Enterprise subdomain within"
+}
+
+variable "friendly_name_prefix" {
+  type        = string
+  description = "Name prefix used for resources"
+}
+
+variable "tfe_subdomain" {
+  type        = string
+  description = "Subdomain for TFE"
+}
+
+variable "tfe_license_name" {
+  type        = string
+  default     = "ptfe-license.rli"
+  description = "The name to use when copying the TFE license file to the EC2 instance."
+}
+
+variable "tfe_license_filepath" {
+  type        = string
+  description = "The absolute path to the TFE license file on the system running Terraform."
+}
+
+variable "common_tags" {
+  default     = {}
+  type        = map(string)
+  description = "(Optional) Map of common tags for all taggable AWS resources."
+}
+
+variable "iact_subnet_list" {
+  default     = ["0.0.0.0/0"]
+  type        = list(string)
+  description = "A list of CIDR masks that configure the ability to retrieve the IACT from outside the host."
+}
+
+variable "load_balancing_scheme" {
+  type        = string
+  default     = "PUBLIC"
+  description = "Load Balancing Scheme. Supported values are: \"PRIVATE\"; \"PRIVATE_TCP\"; \"PUBLIC\"."
+
+  validation {
+    condition     = contains(["PRIVATE", "PRIVATE_TCP", "PUBLIC"], var.load_balancing_scheme)
+    error_message = "The load_balancer value must be one of: \"PRIVATE\"; \"PRIVATE_TCP\"; \"PUBLIC\"."
+  }
+}
+
+# ---
+# AMI
+# ---
+
+variable "ami_owners" {
+  type        = list(string)
+  default     = ["self"]
+  description = "List of AMI owners to limit search."
+}
+
+variable "ami_filter_name" {
+  type        = string
+  default     = "tag"
+  description = "The name of a key off of which to filter with a key/value pair. Example: \"tag:Distro\""
+}
+
+variable "ami_filter_value" {
+  type        = string
+  description = "The value off of which to filter with a key/value pair. Example: \"Ubuntu\""
+}
+
+variable "ami_most_recent" {
+  type        = bool
+  default     = true
+  description = "If more than one result is returned, use the most recent AMI."
+}

--- a/examples/existing-image/versions.tf
+++ b/examples/existing-image/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.15"
+    }
+  }
+}


### PR DESCRIPTION
## Background

[Asana Task](https://app.asana.com/0/1181500399442529/1200247647043881/f)

This branch adds an example for using a non-default image to ensure that users' custom built base images can be consumed by this module.

## How Has This Been Tested

I created a custom image with Packer and filtered on an identifying tag in the data source to use it, and it provisioned as expected.

<img width="400" alt="Screen Shot 2021-06-07 at 4 22 39 PM" src="https://user-images.githubusercontent.com/18335499/121095940-7b315680-c7ae-11eb-805e-6415a9bc96de.png">

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/3orieS4jfHJaKwkeli/giphy.gif)
