### PR TITLE
tests create network

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -566,7 +566,7 @@ jobs:
           echo "::set-output name=token::$( \
             curl --fail --retry 5 --verbose \
             --insecure \
-            --connect-timeout 5 \
+            --connect-timeout 10 \
             --proxy socks5://localhost:5000 "$IACT_URL" )"
 
       - name: Retrieve Initial Admin User URL

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -541,7 +541,7 @@ jobs:
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \
             --insecure \
-            --connect-timeout 5 \
+            --connect-timeout 10 \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \
             $HEALTH_CHECK_URL; \
             do sleep 5; done
@@ -588,7 +588,7 @@ jobs:
           echo "::set-output name=response::$( \
             curl \
             --insecure \
-            --connect-timeout 5 \
+            --connect-timeout 10 \
             --fail \
             --retry 5 \
             --verbose \

--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -8,5 +8,5 @@ locals {
   }
 
   friendly_name_prefix = random_string.friendly_name.id
-
+  ssm_policy_arn       = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -43,7 +43,7 @@ module "private_active_active" {
   deploy_secretsmanager       = false
   external_bootstrap_bucket   = var.external_bootstrap_bucket
   iact_subnet_list            = ["0.0.0.0/0"]
-  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.4xlarge"
   key_name                    = var.key_name
   kms_key_alias               = "test-private-active-active"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -43,7 +43,7 @@ module "private_active_active" {
   deploy_secretsmanager       = false
   external_bootstrap_bucket   = var.external_bootstrap_bucket
   iact_subnet_list            = ["0.0.0.0/0"]
-  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.4xlarge"
   key_name                    = var.key_name
   kms_key_alias               = "${local.friendly_name_prefix}-test-private-active-active"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -41,7 +41,6 @@ module "private_active_active" {
 
   ami_id                       = data.aws_ami.rhel.id
   deploy_secretsmanager        = false
-  deploy_vpc                   = false
   external_bootstrap_bucket    = var.external_bootstrap_bucket
   iact_subnet_list             = ["0.0.0.0/0"]
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
@@ -49,10 +48,6 @@ module "private_active_active" {
   key_name                     = var.key_name
   kms_key_alias                = "test-private-active-active"
   load_balancing_scheme        = "PRIVATE"
-  network_id                   = var.network_id
-  network_private_subnet_cidrs = var.network_private_subnet_cidrs
-  network_private_subnets      = var.network_private_subnets
-  network_public_subnets       = var.network_public_subnets
   node_count                   = 2
   proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
   redis_encryption_at_rest     = false

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -39,22 +39,22 @@ module "private_active_active" {
   friendly_name_prefix = random_string.friendly_name.id
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
-  ami_id                       = data.aws_ami.rhel.id
-  deploy_secretsmanager        = false
-  external_bootstrap_bucket    = var.external_bootstrap_bucket
-  iact_subnet_list             = ["0.0.0.0/0"]
-  iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-  instance_type                = "m5.4xlarge"
-  key_name                     = var.key_name
-  kms_key_alias                = "test-private-active-active"
-  load_balancing_scheme        = "PRIVATE"
-  node_count                   = 2
-  proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
-  redis_encryption_at_rest     = false
-  redis_encryption_in_transit  = true
-  redis_require_password       = true
-  tfe_license_filepath         = ""
-  tfe_subdomain                = "test-private-active-active"
+  ami_id                      = data.aws_ami.rhel.id
+  deploy_secretsmanager       = false
+  external_bootstrap_bucket   = var.external_bootstrap_bucket
+  iact_subnet_list            = ["0.0.0.0/0"]
+  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+  instance_type               = "m5.4xlarge"
+  key_name                    = var.key_name
+  kms_key_alias               = "test-private-active-active"
+  load_balancing_scheme       = "PRIVATE"
+  node_count                  = 2
+  proxy_ip                    = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
+  redis_encryption_at_rest    = false
+  redis_encryption_in_transit = true
+  redis_require_password      = true
+  tfe_license_filepath        = ""
+  tfe_subdomain               = "test-private-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/private-active-active/proxy.tf
+++ b/tests/private-active-active/proxy.tf
@@ -92,5 +92,5 @@ data "aws_iam_policy_document" "proxy_instance_role" {
 
 resource "aws_iam_role_policy_attachment" "ssm" {
   role       = aws_iam_role.proxy_instance_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  policy_arn = local.ssm_policy_arn
 }

--- a/tests/private-active-active/proxy.tf
+++ b/tests/private-active-active/proxy.tf
@@ -17,7 +17,7 @@ resource "aws_instance" "proxy" {
   ami           = data.aws_ami.rhel.id
   instance_type = "m4.large"
 
-  subnet_id = var.network_private_subnets[0]
+  subnet_id = module.private_active_active.private_subnet_ids[0]
 
   vpc_security_group_ids = [
     aws_security_group.proxy.id,
@@ -33,7 +33,7 @@ resource "aws_instance" "proxy" {
 
 resource "aws_security_group" "proxy" {
   name   = "${random_string.friendly_name.result}-sg-proxy-allow"
-  vpc_id = var.network_id
+  vpc_id = module.private_active_active.network_id
 
   tags = merge(
     { Name = "${random_string.friendly_name.result}-sg-proxy-allow" },
@@ -46,7 +46,7 @@ resource "aws_security_group_rule" "proxy_ingress" {
   from_port   = local.http_proxy_port
   to_port     = local.http_proxy_port
   protocol    = "tcp"
-  cidr_blocks = var.network_private_subnet_cidrs
+  cidr_blocks = module.private_active_active.network_private_subnet_cidrs
   description = "Allow internal traffic to proxy instance"
 
   security_group_id = aws_security_group.proxy.id

--- a/tests/private-active-active/proxy.tf
+++ b/tests/private-active-active/proxy.tf
@@ -73,7 +73,7 @@ resource "aws_iam_role" "proxy_instance_role" {
   name_prefix        = "${local.friendly_name_prefix}-proxy-ssm"
   assume_role_policy = data.aws_iam_policy_document.proxy_instance_role.json
 
-  tags = var.common_tags
+  tags = local.common_tags
 }
 
 data "aws_iam_policy_document" "proxy_instance_role" {

--- a/tests/private-active-active/templates/cloud-config-proxy.yaml
+++ b/tests/private-active-active/templates/cloud-config-proxy.yaml
@@ -38,9 +38,12 @@ write_files:
 
 packages:
     - squid
+    - https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 
 runcmd:
     - firewall-cmd --permanent --add-port=${http_proxy_port}/tcp
     - firewall-cmd --reload
     - systemctl start squid
     - systemctl enable squid
+    - systemctl enable amazon-ssm-agent
+    - systemctl start amazon-ssm-agent

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -19,26 +19,6 @@ variable "acm_certificate_arn" {
   description = "The ARN of an existing ACM certificate."
 }
 
-variable "network_id" {
-  description = "The identity of the VPC in which resources will be deployed."
-  type        = string
-}
-
-variable "network_public_subnets" {
-  description = "A list of the identities of the public subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_private_subnets" {
-  description = "A list of the identities of the private subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_private_subnet_cidrs" {
-  type        = list(string)
-  description = "List of private subnet CIDR ranges."
-}
-
 variable "key_name" {
   description = "The name of the key pair to be used for SSH access to the EC2 instance(s)."
   type        = string

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -55,7 +55,7 @@ module "private_tcp_active_active" {
   deploy_secretsmanager       = false
   external_bootstrap_bucket   = var.external_bootstrap_bucket
   iact_subnet_list            = ["0.0.0.0/0"]
-  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.8xlarge"
   kms_key_alias               = "test-private-tcp-active-active"
   load_balancing_scheme       = "PRIVATE_TCP"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -53,17 +53,12 @@ module "private_tcp_active_active" {
 
   ami_id                       = data.aws_ami.rhel.id
   deploy_secretsmanager        = false
-  deploy_vpc                   = false
   external_bootstrap_bucket    = var.external_bootstrap_bucket
   iact_subnet_list             = ["0.0.0.0/0"]
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   instance_type                = "m5.8xlarge"
   kms_key_alias                = "test-private-tcp-active-active"
   load_balancing_scheme        = "PRIVATE_TCP"
-  network_id                   = var.network_id
-  network_private_subnet_cidrs = var.network_private_subnet_cidrs
-  network_private_subnets      = var.network_private_subnets
-  network_public_subnets       = var.network_public_subnets
   node_count                   = 2
   proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
   proxy_cert_bundle_name       = data.aws_s3_bucket_object.proxy_certificate.key

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -51,22 +51,22 @@ module "private_tcp_active_active" {
   friendly_name_prefix = random_string.friendly_name.result
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
-  ami_id                       = data.aws_ami.rhel.id
-  deploy_secretsmanager        = false
-  external_bootstrap_bucket    = var.external_bootstrap_bucket
-  iact_subnet_list             = ["0.0.0.0/0"]
-  iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-  instance_type                = "m5.8xlarge"
-  kms_key_alias                = "test-private-tcp-active-active"
-  load_balancing_scheme        = "PRIVATE_TCP"
-  node_count                   = 2
-  proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
-  proxy_cert_bundle_name       = data.aws_s3_bucket_object.proxy_certificate.key
-  redis_encryption_at_rest     = true
-  redis_encryption_in_transit  = true
-  redis_require_password       = true
-  tfe_license_filepath         = ""
-  tfe_subdomain                = "test-private-tcp-active-active"
+  ami_id                      = data.aws_ami.rhel.id
+  deploy_secretsmanager       = false
+  external_bootstrap_bucket   = var.external_bootstrap_bucket
+  iact_subnet_list            = ["0.0.0.0/0"]
+  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+  instance_type               = "m5.8xlarge"
+  kms_key_alias               = "test-private-tcp-active-active"
+  load_balancing_scheme       = "PRIVATE_TCP"
+  node_count                  = 2
+  proxy_ip                    = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
+  proxy_cert_bundle_name      = data.aws_s3_bucket_object.proxy_certificate.key
+  redis_encryption_at_rest    = true
+  redis_encryption_in_transit = true
+  redis_require_password      = true
+  tfe_license_filepath        = ""
+  tfe_subdomain               = "test-private-tcp-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -19,26 +19,6 @@ variable "acm_certificate_arn" {
   description = "The ARN of an existing ACM certificate."
 }
 
-variable "network_id" {
-  description = "The identity of the VPC in which resources will be deployed."
-  type        = string
-}
-
-variable "network_public_subnets" {
-  description = "A list of the identities of the public subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_private_subnets" {
-  description = "A list of the identities of the private subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_private_subnet_cidrs" {
-  type        = list(string)
-  description = "List of private subnet CIDR ranges."
-}
-
 variable "key_name" {
   description = "The name of the key pair to be used for SSH access to the EC2 instance(s)."
   type        = string

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -19,18 +19,18 @@ module "public_active_active" {
   friendly_name_prefix = random_string.friendly_name.id
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
-  deploy_secretsmanager        = false
-  external_bootstrap_bucket    = var.external_bootstrap_bucket
-  iact_subnet_list             = var.iact_subnet_list
-  instance_type                = "m5.xlarge"
-  kms_key_alias                = "test-public-active-active"
-  load_balancing_scheme        = "PUBLIC"
-  node_count                   = 2
-  redis_encryption_at_rest     = false
-  redis_encryption_in_transit  = false
-  redis_require_password       = false
-  tfe_license_filepath         = ""
-  tfe_subdomain                = "test-public-active-active"
+  deploy_secretsmanager       = false
+  external_bootstrap_bucket   = var.external_bootstrap_bucket
+  iact_subnet_list            = var.iact_subnet_list
+  instance_type               = "m5.xlarge"
+  kms_key_alias               = "test-public-active-active"
+  load_balancing_scheme       = "PUBLIC"
+  node_count                  = 2
+  redis_encryption_at_rest    = false
+  redis_encryption_in_transit = false
+  redis_require_password      = false
+  tfe_license_filepath        = ""
+  tfe_subdomain               = "test-public-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -21,6 +21,7 @@ module "public_active_active" {
 
   deploy_secretsmanager       = false
   external_bootstrap_bucket   = var.external_bootstrap_bucket
+  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list            = var.iact_subnet_list
   instance_type               = "m5.xlarge"
   kms_key_alias               = "test-public-active-active"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -20,16 +20,11 @@ module "public_active_active" {
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
   deploy_secretsmanager        = false
-  deploy_vpc                   = false
   external_bootstrap_bucket    = var.external_bootstrap_bucket
   iact_subnet_list             = var.iact_subnet_list
   instance_type                = "m5.xlarge"
   kms_key_alias                = "test-public-active-active"
   load_balancing_scheme        = "PUBLIC"
-  network_id                   = var.network_id
-  network_private_subnet_cidrs = var.network_private_subnet_cidrs
-  network_private_subnets      = var.network_private_subnets
-  network_public_subnets       = var.network_public_subnets
   node_count                   = 2
   redis_encryption_at_rest     = false
   redis_encryption_in_transit  = false

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -23,23 +23,3 @@ variable "acm_certificate_arn" {
   type        = string
   description = "The ARN of an existing ACM certificate."
 }
-
-variable "network_id" {
-  description = "The identity of the VPC in which resources will be deployed."
-  type        = string
-}
-
-variable "network_public_subnets" {
-  description = "A list of the identities of the public subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_private_subnets" {
-  description = "A list of the identities of the private subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_private_subnet_cidrs" {
-  type        = list(string)
-  description = "List of private subnet CIDR ranges."
-}

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "iact_subnet_time_limit" {
 
 variable "iam_role_policy_arns" {
   default     = []
-  description = "A set of Amazon Resource Names of IAM role policys to be attached to the TFE IAM role."
+  description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."
   type        = set(string)
 }
 


### PR DESCRIPTION
## Background

In order to test that the VPC module is correctly provisioning the network, we'd like to include it in the tests. This branch removes the dependency of an existing network on the test modules.

This branch also adds SSM to the proxy server used in the `private-active-active` test.

[Asana task](https://app.asana.com/0/1181500399442529/1200329454162742/f)

## How Has This Been Tested

I only planned it locally and will test it here.

## This PR makes me feel

![get it out of here](https://media.giphy.com/media/CPJIuTa8kz1MQ/giphy.gif)
