### PR TITLE
randomize key alias

### DIFF
--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -6,4 +6,7 @@ locals {
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
   }
+
+  friendly_name_prefix = random_string.friendly_name.id
+
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -36,7 +36,7 @@ module "private_active_active" {
 
   acm_certificate_arn  = var.acm_certificate_arn
   domain_name          = var.domain_name
-  friendly_name_prefix = random_string.friendly_name.id
+  friendly_name_prefix = local.friendly_name_prefix
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
   ami_id                       = data.aws_ami.rhel.id
@@ -47,7 +47,7 @@ module "private_active_active" {
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   instance_type                = "m5.4xlarge"
   key_name                     = var.key_name
-  kms_key_alias                = "${random_string.friendly_name.id}-test-private-active-active"
+  kms_key_alias                = "${local.friendly_name_prefix}-test-private-active-active"
   load_balancing_scheme        = "PRIVATE"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -59,7 +59,7 @@ module "private_active_active" {
   redis_encryption_in_transit  = true
   redis_require_password       = true
   tfe_license_filepath         = ""
-  tfe_subdomain                = "${random_string.friendly_name.id}-test-private-active-active"
+  tfe_subdomain                = "${local.friendly_name_prefix}-test-private-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -47,7 +47,7 @@ module "private_active_active" {
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   instance_type                = "m5.4xlarge"
   key_name                     = var.key_name
-  kms_key_alias                = "test-private-active-active"
+  kms_key_alias                = "${random_string.friendly_name.id}-test-private-active-active"
   load_balancing_scheme        = "PRIVATE"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -59,7 +59,7 @@ module "private_active_active" {
   redis_encryption_in_transit  = true
   redis_require_password       = true
   tfe_license_filepath         = ""
-  tfe_subdomain                = "test-private-active-active"
+  tfe_subdomain                = "${random_string.friendly_name.id}-test-private-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -8,4 +8,7 @@ locals {
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
   }
+
+  friendly_name_prefix = random_string.friendly_name.id
+
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -58,7 +58,7 @@ module "private_tcp_active_active" {
   iact_subnet_list             = ["0.0.0.0/0"]
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   instance_type                = "m5.8xlarge"
-  kms_key_alias                = "test-private-tcp-active-active"
+  kms_key_alias                = "${random_string.friendly_name.id}-test-private-tcp-active-active"
   load_balancing_scheme        = "PRIVATE_TCP"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -71,7 +71,7 @@ module "private_tcp_active_active" {
   redis_encryption_in_transit  = true
   redis_require_password       = true
   tfe_license_filepath         = ""
-  tfe_subdomain                = "test-private-tcp-active-active"
+  tfe_subdomain                = "${random_string.friendly_name.id}-test-private-tcp-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -48,7 +48,7 @@ module "private_tcp_active_active" {
 
   acm_certificate_arn  = var.acm_certificate_arn
   domain_name          = var.domain_name
-  friendly_name_prefix = random_string.friendly_name.result
+  friendly_name_prefix = local.friendly_name_prefix
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
   ami_id                       = data.aws_ami.rhel.id
@@ -58,7 +58,7 @@ module "private_tcp_active_active" {
   iact_subnet_list             = ["0.0.0.0/0"]
   iam_role_policy_arns         = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   instance_type                = "m5.8xlarge"
-  kms_key_alias                = "${random_string.friendly_name.id}-test-private-tcp-active-active"
+  kms_key_alias                = "${local.friendly_name_prefix}-test-private-tcp-active-active"
   load_balancing_scheme        = "PRIVATE_TCP"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -71,7 +71,7 @@ module "private_tcp_active_active" {
   redis_encryption_in_transit  = true
   redis_require_password       = true
   tfe_license_filepath         = ""
-  tfe_subdomain                = "${random_string.friendly_name.id}-test-private-tcp-active-active"
+  tfe_subdomain                = "${local.friendly_name_prefix}-test-private-tcp-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/public-active-active/locals.tf
+++ b/tests/public-active-active/locals.tf
@@ -6,4 +6,7 @@ locals {
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
   }
+
+  friendly_name_prefix = random_string.friendly_name.id
+
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -16,7 +16,7 @@ module "public_active_active" {
 
   acm_certificate_arn  = var.acm_certificate_arn
   domain_name          = var.domain_name
-  friendly_name_prefix = random_string.friendly_name.id
+  friendly_name_prefix = local.friendly_name_prefix
   tfe_license_name     = "terraform-aws-terraform-enterprise.rli"
 
   deploy_secretsmanager        = false
@@ -24,7 +24,7 @@ module "public_active_active" {
   external_bootstrap_bucket    = var.external_bootstrap_bucket
   iact_subnet_list             = var.iact_subnet_list
   instance_type                = "m5.xlarge"
-  kms_key_alias                = "${random_string.friendly_name.id}-test-public-active-active"
+  kms_key_alias                = "${local.friendly_name_prefix}-test-public-active-active"
   load_balancing_scheme        = "PUBLIC"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -35,7 +35,7 @@ module "public_active_active" {
   redis_encryption_in_transit  = false
   redis_require_password       = false
   tfe_license_filepath         = ""
-  tfe_subdomain                = "${random_string.friendly_name.id}-test-public-active-active"
+  tfe_subdomain                = "${local.friendly_name_prefix}-test-public-active-active"
 
   common_tags = local.common_tags
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -24,7 +24,7 @@ module "public_active_active" {
   external_bootstrap_bucket    = var.external_bootstrap_bucket
   iact_subnet_list             = var.iact_subnet_list
   instance_type                = "m5.xlarge"
-  kms_key_alias                = "test-public-active-active"
+  kms_key_alias                = "${random_string.friendly_name.id}-test-public-active-active"
   load_balancing_scheme        = "PUBLIC"
   network_id                   = var.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -35,7 +35,7 @@ module "public_active_active" {
   redis_encryption_in_transit  = false
   redis_require_password       = false
   tfe_license_filepath         = ""
-  tfe_subdomain                = "test-public-active-active"
+  tfe_subdomain                = "${random_string.friendly_name.id}-test-public-active-active"
 
   common_tags = local.common_tags
 }


### PR DESCRIPTION
## Background

To avoid further failures caused by stale infrastructure, like [this](https://github.com/hashicorp/terraform-aws-terraform-enterprise/runs/2786266475?check_suite_focus=true#step:10:2234), this branch proposes to add the friendly name random id to both the `kms_key_alias` and the `tfe_subdomain` 

Relates to [Asana Task](https://app.asana.com/0/1181500399442529/1200329454162742/f) - error found while testing network additions.
