### PR TITLE
Update default branch references

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -3,7 +3,7 @@ name: Automatic CI for TFE Modules
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -121,4 +121,5 @@ We have included documentation and reference examples for additional common inst
 
 ## License
 
-This code is released under the Mozilla Public License 2.0. Please see [LICENSE](https://github.com/hashicorp/terraform-aws-consul-oss/blob/master/LICENSE) for more details.
+This code is released under the Mozilla Public License 2.0. Please see [LICENSE](https://github.com/hashicorp/terraform-aws-terraform-enterprise/blob/main/LICENSE)
+for more details.


### PR DESCRIPTION
## Background

This branch updates the URL of `LICENSE` in the README and the default branch name in the auto GHA workflow.


## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/3orieSZUPh60IoEOqI/200.gif?cid=5a38a5a2br6vw2jan2gtnm5r8ypegtzg73zw6b8csutl4ix6&rid=200.gif&ct=g)
