### PR TITLE
Clarify test reports

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -173,23 +173,20 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ### ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.destroy.outcome == "success" || (steps.destroy.outcome == "skipped" && steps.run-smoke-test.outcome == "success")] }} Terraform Public Active/Active Test Report
 
-            ### Terraform Public Active/Active Test Report :newspaper:
+            :link: [Action Summary Page](${{ steps.vars.outputs.run-url }})
 
-            - Terraform Initialization :gear: `${{ steps.init.outcome }}`
+            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.init.outcome == "success"] }} Terraform Init
 
-            - Terraform Validation :mag: `${{ steps.validate.outcome }}`
+            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.validate.outcome == "success"] }} Terraform Validate
 
-            - Terraform Apply :book: `${{ steps.apply.outcome }}`
+            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.apply.outcome == "success"] }} Terraform Apply
 
-            - K6 Smoke Test :building_construction: `${{ steps.run-smoke-test.outcome }}`
+            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.run-smoke-test.outcome == "success"] }} Run k6 Smoke Test
 
-            - Terraform Destroy :fire: `${{ steps.destroy.outcome }}`
+            ${{ fromJSON('["", "- ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.destroy.outcome == "success"] }} Terraform Destroy"]')[github.event.client_payload.slash_command.args.named.destroy != 'false'] }}
 
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
   private_active_active:
     name: Run tf-test on Private Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -173,7 +173,7 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            ### ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.destroy.outcome == "success" || (steps.destroy.outcome == "skipped" && steps.run-smoke-test.outcome == "success")] }} Terraform Public Active/Active Test Report
+            ### ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[job.status == "success"] }} Terraform Public Active/Active Test Report
 
             :link: [Action Summary Page](${{ steps.vars.outputs.run-url }})
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -173,19 +173,19 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            ### ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[job.status == "success"] }} Terraform Public Active/Active Test Report
+            ### ${{ fromJSON('[":x:", ":white_check_mark:"]')[job.status == "success"] }} Terraform Public Active/Active Test Report
 
             :link: [Action Summary Page](${{ steps.vars.outputs.run-url }})
 
-            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.init.outcome == "success"] }} Terraform Init
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.init.outcome == "success"] }} Terraform Init
 
-            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.validate.outcome == "success"] }} Terraform Validate
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.validate.outcome == "success"] }} Terraform Validate
 
-            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.apply.outcome == "success"] }} Terraform Apply
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.apply.outcome == "success"] }} Terraform Apply
 
-            - ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.run-smoke-test.outcome == "success"] }} Run k6 Smoke Test
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.run-smoke-test.outcome == "success"] }} Run k6 Smoke Test
 
-            ${{ fromJSON('["", "- ${{ fromJSON('[":x:", ":heavy_check_mark:"]')[steps.destroy.outcome == "success"] }} Terraform Destroy"]')[github.event.client_payload.slash_command.args.named.destroy != 'false'] }}
+            ${{ fromJSON('["", "- ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.destroy.outcome == "success"] }} Terraform Destroy"]')[github.event.client_payload.slash_command.args.named.destroy != 'false'] }}
 
   private_active_active:
     name: Run tf-test on Private Active/Active

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -395,23 +395,19 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ### ${{ fromJSON('[":x:", ":white_check_mark:"]')[job.status == "success"] }} Terraform Private Active/Active Test Report
 
-            ### Terraform Private Active/Active Test Report :newspaper:
+            :link: [Action Summary Page](${{ steps.vars.outputs.run-url }})
 
-            - Terraform Initialization :gear: `${{ steps.init.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.init.outcome == "success"] }} Terraform Init
 
-            - Terraform Validation :mag: `${{ steps.validate.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.validate.outcome == "success"] }} Terraform Validate
 
-            - Terraform Apply :book: `${{ steps.apply.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.apply.outcome == "success"] }} Terraform Apply
 
-            - K6 Smoke Test :building_construction: `${{ steps.run-smoke-test.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.run-smoke-test.outcome == "success"] }} Run k6 Smoke Test
 
-            - Terraform Destroy :fire: `${{ steps.destroy.outcome }}`
-
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
+            ${{ fromJSON('["", "- ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.destroy.outcome == "success"] }} Terraform Destroy"]')[github.event.client_payload.slash_command.args.named.destroy != 'false'] }}
 
   private_tcp_active_active:
     name: Run tf-test on Private TCP Active/Active
@@ -631,20 +627,16 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ### ${{ fromJSON('[":x:", ":white_check_mark:"]')[job.status == "success"] }} Terraform Private TCP Active/Active Test Report
 
-            ### Terraform Private TCP Active/Active Test Report :newspaper:
+            :link: [Action Summary Page](${{ steps.vars.outputs.run-url }})
 
-            - Terraform Initialization :gear: `${{ steps.init.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.init.outcome == "success"] }} Terraform Init
 
-            - Terraform Validation :mag: `${{ steps.validate.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.validate.outcome == "success"] }} Terraform Validate
 
-            - Terraform Apply :book: `${{ steps.apply.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.apply.outcome == "success"] }} Terraform Apply
 
-            - K6 Smoke Test :building_construction: `${{ steps.run-smoke-test.outcome }}`
+            - ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.run-smoke-test.outcome == "success"] }} Run k6 Smoke Test
 
-            - Terraform Destroy :fire: `${{ steps.destroy.outcome }}`
-
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
+            ${{ fromJSON('["", "- ${{ fromJSON('[":x:", ":white_check_mark:"]')[steps.destroy.outcome == "success"] }} Terraform Destroy"]')[github.event.client_payload.slash_command.args.named.destroy != 'false'] }}


### PR DESCRIPTION
## Background

This branch updates the Test Report comments to be more clear.

Currently, just the first report is updated until we are done iterating on the design.

The intention is to show a :white_check_mark: or :x: for the overall test job, as well as each of its major steps. :white_check_mark: was selected over :heavy_check_mark: as the latter renders differently depending on the browser.

[Asana task](https://app.asana.com/0/1181500399442529/1200449299638599/f)

## Mock Up

- The title includes :x: or :white_check_mark: depending on the overall status of the test scenario job.
- The link to the particular run is moved to the top.
- Each Terraform step includes :x: or :white_check_mark: depending on their outcomes

### :x: Terraform Public Active/Active Test Report
:link: [Action Summary Page](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/947583258)
- :white_check_mark: Terraform Init
- :white_check_mark: Terraform Validate
- :white_check_mark: Terraform Apply
- :x: Run k6 Smoke Test
- :white_check_mark: Terraform Destroy

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/h20lvKHKftLywvmGA5/giphy.gif?cid=5a38a5a2dpk0co311mf54cbc3833zveafjfviczubiiw63ok&rid=giphy.gif&ct=g)
