### PR TITLE
change private test user to ubuntu

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -302,7 +302,7 @@ jobs:
                 --parameters \"portNumber=%p\""' \
             -i ./ssh-key.pem \
             -f -N -p 22 -D localhost:5000 \
-            ec2-user@"$INSTANCE_ID"
+            ubuntu@"$INSTANCE_ID"
 
       - name: Wait For TFE
         id: wait-for-tfe


### PR DESCRIPTION
## Background

Due to flaky SSM installations, we need to change the private test's proxy server to Ubuntu, which has it already installed. Because of that, we'll need to change the user in the workflow.

[Asana task](/etc/apt/apt.conf)

## This PR makes me feel

![change user](https://media.giphy.com/media/l2JdZ1D3KPMHFsdVK/giphy.gif)
