### PR TITLE
Enable DB backups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,8 @@ module "database" {
   source = "./modules/database"
 
   db_size                      = var.db_size
+  db_backup_retention          = var.db_backup_retention
+  db_backup_window             = var.db_backup_window
   engine_version               = var.postgres_engine_version
   friendly_name_prefix         = var.friendly_name_prefix
   network_id                   = local.network_id

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -60,7 +60,8 @@ resource "aws_db_instance" "postgresql" {
 
   allow_major_version_upgrade = false
   apply_immediately           = true
-  backup_retention_period     = 0
+  backup_retention_period     = var.db_backup_retention
+  backup_window               = var.db_backup_window
   db_subnet_group_name        = aws_db_subnet_group.tfe.name
   delete_automated_backups    = true
   deletion_protection         = false

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -11,6 +11,18 @@ variable "db_size" {
   description = "PostgreSQL instance size."
 }
 
+variable "db_backup_retention" {
+  type        = number
+  description = "The days to retain backups for. Must be between 0 and 35"
+  default     = 0
+}
+
+variable "db_backup_window" {
+  type        = string
+  description = "The daily time range (in UTC) during which automated backups are created if they are enabled"
+  default     = null
+}
+
 variable "engine_version" {
   type        = string
   default     = "9.5.15"

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,18 @@ variable "db_size" {
   description = "PostgreSQL instance size."
 }
 
+variable "db_backup_retention" {
+  type        = number
+  description = "The days to retain backups for. Must be between 0 and 35"
+  default     = 0
+}
+
+variable "db_backup_window" {
+  type        = string
+  description = "The daily time range (in UTC) during which automated backups are created if they are enabled"
+  default     = null
+}
+
 variable "postgres_engine_version" {
   type        = string
   default     = "9.6.20"


### PR DESCRIPTION
## Background

This PR gives the option to enable automated backups on RDS
By default, it keeps the same behaviour with no automated backups enabled

### Test Configuration

* Terraform Version: v1.0.0
* Any additional relevant variables: `db_backup_retention` and `db_backup_window`

## This PR makes me feel

![safe](https://media.giphy.com/media/ZeFHO8lptBLWSwBV7H/giphy.gif)
