### PR TITLE
Update destroy report

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   public_active_active:
-    name: Destroy resources from Public Active/Active test
+    name: Destroy resources from Public Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
     runs-on: ubuntu-latest
     permissions:
@@ -56,17 +56,13 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ${{ format('### {0} Terraform Public Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
 
-            ### Terraform Public Active/Active Destruction Report :newspaper:
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
 
-            - `${{ steps.init.outcome }}` Terraform Initialization :gear: 
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
-            - `${{ steps.destroy.outcome }}` Terraform Destroy :fire:
-
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
+            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
   private_active_active:
     name: Destroy resources from Private Active/Active
@@ -118,17 +114,13 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ${{ format('### {0} Terraform Private Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
 
-            ### Terraform Private Active/Active Destruction Report :newspaper:
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
 
-            - `${{ steps.init.outcome }}` Terraform Initialization :gear: 
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
-            - `${{ steps.destroy.outcome }}` Terraform Destroy :fire:
-
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
+            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
   private_tcp_active_active:
     name: Destroy resources from Private TCP Active/Active
@@ -180,14 +172,10 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ${{ format('### {0} Terraform Private TCP Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
 
-            ### Terraform Private TCP Active/Active Destruction Report :newspaper:
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
 
-            - `${{ steps.init.outcome }}` Terraform Initialization :gear: 
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
-            - `${{ steps.destroy.outcome }}` Terraform Destroy :fire:
-
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
+            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}


### PR DESCRIPTION
## Background

This branch updates the format of the `/destroy` report to match that of the `/test` report. 


An example of the output is available in https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/86#issuecomment-897644495.

## How Has This Been Tested

Tested in the linked pull request.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/VEhpX9lshFoFHNS563/giphy.gif?cid=5a38a5a2weqh3na1uiqv2drwcm5umaexh5r1byfocpcdhyrp&rid=giphy.gif&ct=g)
