### PR TITLE
add vars for set-output values

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -111,8 +111,8 @@ jobs:
         env:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
-          echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose "$IACT_URL" )"
+          token=$(curl --fail --retry 5 --verbose "$IACT_URL")
+          echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -130,21 +130,23 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
-          echo "::set-output name=response::$( \
+          response=$( \
             curl \
             --fail \
             --retry 5 \
             --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \
-            "$IAU_URL"?token="$IACT")"
+            "$IAU_URL"?token="$IACT")
+          echo "::set-output name=response::$response"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
         env:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test
@@ -330,8 +332,8 @@ jobs:
         env:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
-          echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL" )"
+          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL")
+          echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -349,7 +351,7 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
-          echo "::set-output name=response::$( \
+          response=$( \
             curl \
             --fail \
             --retry 5 \
@@ -357,14 +359,16 @@ jobs:
             --header 'Content-Type: application/json' \
             --data @./payload.json \
             --proxy socks5://localhost:5000 \
-            "$IAU_URL"?token="$IACT_TOKEN")"
+            "$IAU_URL"?token="$IACT_TOKEN")
+          echo "::set-output name=response::$response"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
         env:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test
@@ -556,11 +560,12 @@ jobs:
         env:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
-          echo "::set-output name=token::$( \
+          token=$( \
             curl --fail --retry 5 --verbose \
             --insecure \
             --connect-timeout 10 \
-            --proxy socks5://localhost:5000 "$IACT_URL" )"
+            --proxy socks5://localhost:5000 "$IACT_URL")
+          echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -578,7 +583,7 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
-          echo "::set-output name=response::$( \
+          response=$( \
             curl \
             --insecure \
             --connect-timeout 10 \
@@ -588,14 +593,16 @@ jobs:
             --header 'Content-Type: application/json' \
             --data @./payload.json \
             --proxy socks5://localhost:5000 \
-            "$IAU_URL"?token="$IACT_TOKEN")"
+            "$IAU_URL"?token="$IACT_TOKEN")
+          echo "::set-output name=response::$response"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
         env:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test


### PR DESCRIPTION
## Background

From previous PR to [GCP module](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/104)
> Currently, if a ::set-output command sets a value to be the output of a curl command that fails, the value is set to an empty string. This branch changes it so that the curl output is stored in a variable first, and then the ::set-output command uses the variable. This way, if curl fails, the build will fail.

[Asana task](https://app.asana.com/0/1181500399442529/1200819228490425/f)

## How Has This Been Tested

Changes were first made to the [GCP TFE Module](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/104) and a followup [bug fix](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/105).

## This PR makes me feel

![curling](https://media.giphy.com/media/kEWvxeoP9b1HShmFes/giphy.gif)
