### PR TITLE
Support S3 Access Key and Add A/A RHEL Proxy Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 
 # Editor files
 .vscode
- 
+
 # TFE license
 *.rli
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  iam_principal = { arn = try(var.object_storage_iam_principal.arn, module.service_accounts.iam_role.arn) }
+  iam_principal = { arn = try(var.object_storage_iam_user.arn, module.service_accounts.iam_role.arn) }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  iam_principal = { arn = try(var.object_storage_iam_principal.arn, module.service_accounts.iam_role.arn) }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,11 @@
 locals {
-  iam_principal = { arn = try(var.object_storage_iam_user.arn, module.service_accounts.iam_role.arn) }
+  active_active                = var.node_count >= 2
+  ami_id                       = local.default_ami_id ? data.aws_ami.ubuntu.id : var.ami_id
+  default_ami_id               = var.ami_id == ""
+  fqdn                         = "${var.tfe_subdomain}.${var.domain_name}"
+  iam_principal                = { arn = try(var.object_storage_iam_user.arn, module.service_accounts.iam_role.arn) }
+  network_id                   = var.deploy_vpc ? module.networking[0].network_id : var.network_id
+  network_private_subnets      = var.deploy_vpc ? module.networking[0].network_private_subnets : var.network_private_subnets
+  network_public_subnets       = var.deploy_vpc ? module.networking[0].network_public_subnets : var.network_public_subnets
+  network_private_subnet_cidrs = var.deploy_vpc ? module.networking[0].network_private_subnet_cidrs : var.network_private_subnet_cidrs
 }

--- a/main.tf
+++ b/main.tf
@@ -16,13 +16,6 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
-locals {
-  active_active  = var.node_count >= 2
-  ami_id         = local.default_ami_id ? data.aws_ami.ubuntu.id : var.ami_id
-  default_ami_id = var.ami_id == ""
-  fqdn           = "${var.tfe_subdomain}.${var.domain_name}"
-}
-
 module "service_accounts" {
   source = "./modules/service_accounts"
 
@@ -57,13 +50,6 @@ module "networking" {
   network_cidr                 = var.network_cidr
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
   network_public_subnet_cidrs  = var.network_public_subnet_cidrs
-}
-
-locals {
-  network_id                   = var.deploy_vpc ? module.networking[0].network_id : var.network_id
-  network_private_subnets      = var.deploy_vpc ? module.networking[0].network_private_subnets : var.network_private_subnets
-  network_public_subnets       = var.deploy_vpc ? module.networking[0].network_public_subnets : var.network_public_subnets
-  network_private_subnet_cidrs = var.deploy_vpc ? module.networking[0].network_private_subnet_cidrs : var.network_private_subnet_cidrs
 }
 
 module "redis" {

--- a/main.tf
+++ b/main.tf
@@ -116,8 +116,10 @@ module "user_data" {
 
   tfe_license_secret     = var.tfe_license_secret
   active_active          = local.active_active
+  aws_access_key_id      = var.aws_access_key_id
   aws_bucket_data        = module.object_storage.s3_bucket_data
   aws_region             = data.aws_region.current.name
+  aws_secret_access_key  = var.aws_secret_access_key
   fqdn                   = local.fqdn
   iact_subnet_list       = var.iact_subnet_list
   iact_subnet_time_limit = var.iact_subnet_time_limit

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -1,0 +1,28 @@
+resource "aws_kms_key" "main" {
+  deletion_window_in_days = var.key_deletion_window
+  description             = "AWS KMS Customer-managed key to encrypt TFE and other resources"
+  enable_key_rotation     = false
+  is_enabled              = true
+  key_usage               = "ENCRYPT_DECRYPT"
+}
+
+resource "aws_kms_alias" "main" {
+  name          = "alias/${var.key_alias}"
+  target_key_id = aws_kms_key.main.key_id
+}
+
+resource "aws_kms_grant" "main" {
+  grantee_principal = var.iam_principal.arn
+  key_id            = aws_kms_key.main.key_id
+  operations = [
+    "Decrypt",
+    "DescribeKey",
+    "Encrypt",
+    "GenerateDataKey",
+    "GenerateDataKeyPair",
+    "GenerateDataKeyPairWithoutPlaintext",
+    "GenerateDataKeyPairWithoutPlaintext",
+    "ReEncryptFrom",
+    "ReEncryptTo",
+  ]
+}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -1,0 +1,5 @@
+output "key" {
+  value = aws_kms_key.main
+
+  description = "The KMS key used to encrypt data."
+}

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -10,5 +10,5 @@ variable "key_deletion_window" {
 
 variable "iam_principal" {
   description = "The IAM principal (role or user) that will be authorized to use the key."
-  type = object({ arn = string})
+  type        = object({ arn = string })
 }

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -1,0 +1,14 @@
+variable "key_alias" {
+  description = "The key alias for AWS KMS Customer managed key."
+  type        = string
+}
+
+variable "key_deletion_window" {
+  description = "Duration in days to destroy the key after it is deleted. Must be between 7 and 30 days."
+  type        = number
+}
+
+variable "iam_principal" {
+  description = "The IAM principal (role or user) that will be authorized to use the key."
+  type = object({ arn = string})
+}

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.38"
+    }
+  }
+}

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -26,3 +26,39 @@ resource "aws_s3_bucket_public_access_block" "tfe_data" {
   restrict_public_buckets = true
   ignore_public_acls      = true
 }
+
+data "aws_iam_policy_document" "tfe_data" {
+  statement {
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+    effect  = "Allow"
+    principals {
+      identifiers = [var.iam_principal.arn]
+      type        = "AWS"
+    }
+    resources = [aws_s3_bucket.tfe_data_bucket.arn]
+    sid       = "AllowS3ListBucketData"
+  }
+
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    effect = "Allow"
+    principals {
+      identifiers = [var.iam_principal.arn]
+      type        = "AWS"
+    }
+    resources = ["${aws_s3_bucket.tfe_data_bucket.arn}/*"]
+    sid       = "AllowS3ManagementData"
+  }
+}
+
+resource "aws_s3_bucket_policy" "tfe_data" {
+  bucket = aws_s3_bucket.tfe_data_bucket.id
+  policy = data.aws_iam_policy_document.tfe_data.json
+}

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -59,6 +59,8 @@ data "aws_iam_policy_document" "tfe_data" {
 }
 
 resource "aws_s3_bucket_policy" "tfe_data" {
-  bucket = aws_s3_bucket.tfe_data_bucket.id
+  # Depending on aws_s3_bucket_public_access_block.tfe_data avoids an error due to conflicting, simultaneous operations
+  # against the bucket.
+  bucket = aws_s3_bucket_public_access_block.tfe_data.bucket
   policy = data.aws_iam_policy_document.tfe_data.json
 }

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "tfe_data" {
       "s3:GetBucketLocation",
       "s3:ListBucket",
     ]
-    effect  = "Allow"
+    effect = "Allow"
     principals {
       identifiers = [var.iam_principal.arn]
       type        = "AWS"

--- a/modules/object_storage/outputs.tf
+++ b/modules/object_storage/outputs.tf
@@ -1,11 +1,5 @@
-output "s3_bucket_data" {
-  value = aws_s3_bucket.tfe_data_bucket.id
+output "s3_bucket" {
+  value = aws_s3_bucket.tfe_data_bucket
 
-  description = "The name of the S3 bucket which contains TFE runtime data."
-}
-
-output "s3_bucket_data_arn" {
-  value = aws_s3_bucket.tfe_data_bucket.arn
-
-  description = "The Amazon Resource Name of the S3 bucket which contains TFE runtime data."
+  description = "The S3 bucket which contains TFE runtime data."
 }

--- a/modules/object_storage/variables.tf
+++ b/modules/object_storage/variables.tf
@@ -7,3 +7,8 @@ variable "friendly_name_prefix" {
   type        = string
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
 }
+
+variable "iam_principal" {
+  description = "The IAM principal (role or user) that will be authorized to access the S3 storage bucket."
+  type        = object({ arn = string })
+}

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -38,40 +38,6 @@ data "aws_iam_policy_document" "secretsmanager" {
   }
 }
 
-resource "aws_iam_role_policy" "s3_data_bucket_put" {
-  name   = "${var.friendly_name_prefix}-tfe-data"
-  role   = aws_iam_role.instance_role.id
-  policy = data.aws_iam_policy_document.tfe_s3_data_bucket_put.json
-}
-
-data "aws_iam_policy_document" "tfe_s3_data_bucket_put" {
-  statement {
-    sid    = "AllowS3ActionsData"
-    effect = "Allow"
-    actions = [
-      "s3:*"
-    ]
-    resources = [
-      var.aws_bucket_data_arn,
-      "${var.aws_bucket_data_arn}/*"
-    ]
-  }
-
-  statement {
-    sid    = "AllowKMSActionsData"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:ReEncrypt",
-      "kms:GenerateDataKey",
-      "kms:DescribeKey",
-    ]
-    resources = [
-      var.kms_key_arn,
-    ]
-  }
-}
-
 resource "aws_iam_role_policy" "tfe_asg_discovery" {
   name   = "${var.friendly_name_prefix}-tfe-asg-discovery"
   role   = aws_iam_role.instance_role.id

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -1,8 +1,11 @@
-output "aws_iam_instance_profile" {
-  value = aws_iam_instance_profile.tfe.name
+output "iam_instance_profile" {
+  value = aws_iam_instance_profile.tfe
 
-  description = <<-EOD
-  The name of the IAM instance profile to be attached to the TFE EC2 instance(s) which is authorized to access the S3 
-  storage buckets and EC2 autoscaling group.
-  EOD
+  description = "The IAM instance profile to be attached to the TFE EC2 instance(s)."
+}
+
+output "iam_role" {
+  value = aws_iam_role.instance_role
+
+  description = "The IAM role associated with the instance profile."
 }

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -3,16 +3,6 @@ variable "friendly_name_prefix" {
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
 }
 
-variable "aws_bucket_data_arn" {
-  description = "The Amazon Resource Name of the S3 storage bucket whih contains TFE runtime data."
-  type        = string
-}
-
-variable "kms_key_arn" {
-  description = "The Amazon Resource Name of the KMS key which is used to encrypt S3 storage bucket objects."
-  type        = string
-}
-
 variable "iam_role_policy_arns" {
   default     = []
   description = "A set of Amazon Resource Names of IAM role policys to be attached to the TFE IAM role."

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -125,7 +125,15 @@ locals {
     }
 
     aws_instance_profile = {
-      value = "1"
+      value = var.aws_access_key_id == null ? "1" : "0"
+    }
+
+    aws_access_key_id = {
+      value = var.aws_access_key_id
+    }
+
+    aws_secret_access_key = {
+      value = var.aws_secret_access_key
     }
 
     s3_bucket = {

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -16,6 +16,22 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_access_key_id" {
+  description = <<-EOD
+  The identity of the access key which TFE will use to authenticate with S3. This value requires var.
+  aws_secret_access_key to also be set. If this value is null then the IAM instance profile of the EC2 instance which
+  hosts will be used instead.
+  EOD
+  type        = string
+}
+
+variable "aws_secret_access_key" {
+  description = <<-EOD
+  The secret access key which TFE will use to authenticate with S3. This value requires var.aws_secret_access_key to also be set.
+  EOD
+  type        = string
+}
+
 variable "tfe_license_secret" {
   type = object({
     arn = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -64,9 +64,20 @@ output "dns_configuration_notice" {
   description = "A notice to inform users of how to configure an external DNS service to direct traffic to the load balancer."
 }
 
+output "health_check_url" {
+  value = "https://${local.fqdn}/_health_check"
+
+  description = "The URL of the Terraform Enterprise health check endpoint."
+}
+
 output "login_url" {
   value       = "https://${local.fqdn}/admin/account/new?token=${module.user_data.user_token.value}"
   description = "Login URL to setup the TFE instance once it is initialized"
+}
+
+output "replicated_console_url" {
+  value       = "https://${local.fqdn}:8800/"
+  description = "The URL of the Terraform Enterprise administration console."
 }
 
 output "tfe_url" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,8 @@
 # KMS
-output "kms_key_arn" {
-  value = aws_kms_key.tfe_key.arn
+output "kms_key" {
+  value = module.kms.key
 
-  description = "The Amazon Resource Name of the KMS key used to encrypt data at rest."
-}
-
-output "kms_key_id" {
-  value = aws_kms_key.tfe_key.key_id
-
-  description = "The identity of the KMS key used to encrypt data at rest."
+  description = "The KMS key used to encrypt data at rest."
 }
 
 # Network

--- a/tests/active-active-rhel-proxy/README.md
+++ b/tests/active-active-rhel-proxy/README.md
@@ -1,0 +1,26 @@
+# Test: Active/Active Terraform Enterprise on RHEL with Proxy
+
+## About this test
+
+This test for Terraform Enterprise creates a TFE installation with the
+following traits:
+
+- Active/Active mode
+- a small VM machine type (m5.xlarge)
+- Red Hat 7.8 as the VM image
+- a publicly accessible HTTP load balancer with TLS termination
+- a proxy server with TLS termination
+- an access key for accessing S3
+
+## Pre-requisites
+
+This test assumes the following resources already exist:
+
+- Valid DNS Zone managed in Route53
+- Valid AWS ACM certificate
+- a TFE license on a filepath accessible by tests
+
+## How this test is used
+
+This test is leveraged by the integration tests in the
+`ptfe-replicated` repository.

--- a/tests/active-active-rhel-proxy/data.tf
+++ b/tests/active-active-rhel-proxy/data.tf
@@ -1,0 +1,83 @@
+data "aws_secretsmanager_secret" "ca_certificate" {
+  name = "terraform-20211022160427310700000001"
+}
+
+data "aws_secretsmanager_secret" "ca_private_key" {
+  name = "terraform-20211022160427312200000003"
+}
+
+data "aws_ami" "rhel" {
+  owners = ["309956199498"] # RedHat
+
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_iam_policy_document" "instance_role" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "secretsmanager" {
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    effect    = "Allow"
+    resources = [data.aws_secretsmanager_secret.ca_certificate.arn, data.aws_secretsmanager_secret.ca_private_key.arn]
+    sid       = "AllowSecretsManagerSecretAccess"
+  }
+}
+
+data "aws_iam_user" "object_storage" {
+  user_name = var.object_storage_iam_user_name
+}
+
+data "aws_instances" "tfe" {
+  instance_tags = local.common_tags
+
+  depends_on = [
+    null_resource.wait_for_instances
+  ]
+}
+
+# This null_data_source is used to prevent Terraform from trying to render local_file.ssh_config file before data.
+# aws_instances.tfe is available.
+# See https://github.com/hashicorp/terraform-provider-local/issues/57
+data "null_data_source" "instance" {
+  inputs = {
+    id = data.aws_instances.tfe.ids[0]
+  }
+}

--- a/tests/active-active-rhel-proxy/locals.tf
+++ b/tests/active-active-rhel-proxy/locals.tf
@@ -1,0 +1,17 @@
+locals {
+  http_proxy_port = 3128
+
+  common_tags = {
+    Terraform   = "cloud"
+    Environment = "team_tfe_dev"
+    Description = "Active/Active on RHEL with Proxy scenario deployed from CircleCI"
+    Repository  = "hashicorp/terraform-aws-terraform-enterprise"
+    Team        = "Terraform Enterprise on Prem"
+    OkToDelete  = "True"
+  }
+
+  friendly_name_prefix = random_string.friendly_name.id
+  ssh_user             = "ec2-user"
+  ssm_policy_arn       = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  test_name            = "${local.friendly_name_prefix}-test-active-active-rhel-proxy"
+}

--- a/tests/active-active-rhel-proxy/main.tf
+++ b/tests/active-active-rhel-proxy/main.tf
@@ -1,0 +1,81 @@
+resource "random_string" "friendly_name" {
+  length  = 4
+  upper   = false # Some AWS resources do not accept uppercase characters.
+  number  = false
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "tfe_license" {
+  description = "The TFE license."
+}
+
+resource "aws_secretsmanager_secret_version" "tfe_license" {
+  secret_binary = filebase64(var.license_file)
+  secret_id     = aws_secretsmanager_secret.tfe_license.id
+}
+
+resource "tls_private_key" "main" {
+  algorithm = "RSA"
+}
+
+resource "local_file" "private_key_pem" {
+  filename = "${path.module}/work/private-key.pem"
+
+  content         = tls_private_key.main.private_key_pem
+  file_permission = "0600"
+}
+
+resource "aws_key_pair" "main" {
+  public_key = tls_private_key.main.public_key_openssh
+
+  key_name = "${local.friendly_name_prefix}-ssh"
+}
+
+module "tfe" {
+  source = "../../"
+
+  acm_certificate_arn  = var.acm_certificate_arn
+  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  friendly_name_prefix = local.friendly_name_prefix
+  tfe_license_secret   = aws_secretsmanager_secret.tfe_license
+
+  ami_id                       = data.aws_ami.rhel.id
+  aws_access_key_id            = var.aws_access_key_id
+  aws_secret_access_key        = var.aws_secret_access_key
+  ca_certificate_secret        = data.aws_secretsmanager_secret.ca_certificate
+  iact_subnet_list             = ["0.0.0.0/0"]
+  iam_role_policy_arns         = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  instance_type                = "m5.xlarge"
+  key_name                     = aws_key_pair.main.key_name
+  kms_key_alias                = local.test_name
+  load_balancing_scheme        = "PUBLIC"
+  object_storage_iam_principal = data.aws_iam_user.object_storage
+  node_count                   = 2
+  proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
+  tfe_subdomain                = local.test_name
+
+  asg_tags = local.common_tags
+}
+
+resource "null_resource" "wait_for_instances" {
+  triggers = {
+    arn = module.tfe.tfe_autoscaling_group.arn
+  }
+
+  provisioner "local-exec" {
+    command = "sleep 30"
+  }
+}
+
+resource "local_file" "ssh_config" {
+  filename = "${path.module}/work/ssh-config"
+
+  content = templatefile(
+    "${path.module}/templates/ssh-config.tpl",
+    {
+      instance      = data.null_data_source.instance.outputs
+      identity_file = local_file.private_key_pem.filename
+      user          = local.ssh_user
+    }
+  )
+}

--- a/tests/active-active-rhel-proxy/main.tf
+++ b/tests/active-active-rhel-proxy/main.tf
@@ -39,20 +39,20 @@ module "tfe" {
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 
-  ami_id                       = data.aws_ami.rhel.id
-  aws_access_key_id            = var.aws_access_key_id
-  aws_secret_access_key        = var.aws_secret_access_key
-  ca_certificate_secret        = data.aws_secretsmanager_secret.ca_certificate
-  iact_subnet_list             = ["0.0.0.0/0"]
-  iam_role_policy_arns         = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  instance_type                = "m5.xlarge"
-  key_name                     = aws_key_pair.main.key_name
-  kms_key_alias                = local.test_name
-  load_balancing_scheme        = "PUBLIC"
-  object_storage_iam_principal = data.aws_iam_user.object_storage
-  node_count                   = 2
-  proxy_ip                     = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
-  tfe_subdomain                = local.test_name
+  ami_id                  = data.aws_ami.rhel.id
+  aws_access_key_id       = var.aws_access_key_id
+  aws_secret_access_key   = var.aws_secret_access_key
+  ca_certificate_secret   = data.aws_secretsmanager_secret.ca_certificate
+  iact_subnet_list        = ["0.0.0.0/0"]
+  iam_role_policy_arns    = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  instance_type           = "m5.xlarge"
+  key_name                = aws_key_pair.main.key_name
+  kms_key_alias           = local.test_name
+  load_balancing_scheme   = "PUBLIC"
+  object_storage_iam_user = data.aws_iam_user.object_storage
+  node_count              = 2
+  proxy_ip                = "${aws_instance.proxy.private_ip}:${local.http_proxy_port}"
+  tfe_subdomain           = local.test_name
 
   asg_tags = local.common_tags
 }

--- a/tests/active-active-rhel-proxy/outputs.tf
+++ b/tests/active-active-rhel-proxy/outputs.tf
@@ -1,0 +1,31 @@
+output "replicated_console_password" {
+  value       = module.tfe.replicated_dashboard_password
+  description = "The password for the TFE console"
+}
+
+output "replicated_console_url" {
+  value       = module.tfe.replicated_console_url
+  description = "Terraform Enterprise Console URL"
+}
+
+output "ptfe_endpoint" {
+  value       = module.tfe.tfe_url
+  description = "Terraform Enterprise Application URL"
+}
+
+output "ptfe_health_check" {
+  value       = module.tfe.health_check_url
+  description = "Terraform Enterprise Health Check URL"
+}
+
+output "ssh_config_file" {
+  value = local_file.ssh_config.filename
+
+  description = "The pathname of the SSH configuration file that grants access to the compute instance."
+}
+
+output "ssh_private_key" {
+  value = local_file.private_key_pem.filename
+
+  description = "The pathname of the private SSH key."
+}

--- a/tests/active-active-rhel-proxy/providers.tf
+++ b/tests/active-active-rhel-proxy/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  # assume_role {
+  #   role_arn = var.aws_role_arn
+  # }
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/tests/active-active-rhel-proxy/providers.tf
+++ b/tests/active-active-rhel-proxy/providers.tf
@@ -1,7 +1,7 @@
 provider "aws" {
-  # assume_role {
-  #   role_arn = var.aws_role_arn
-  # }
+  assume_role {
+    role_arn = var.aws_role_arn
+  }
 
   default_tags {
     tags = local.common_tags

--- a/tests/active-active-rhel-proxy/proxy.tf
+++ b/tests/active-active-rhel-proxy/proxy.tf
@@ -1,0 +1,82 @@
+resource "aws_security_group" "proxy" {
+  name   = "${local.friendly_name_prefix}-sg-proxy-allow"
+  vpc_id = module.tfe.network_id
+
+  # Prefix removed until https://github.com/hashicorp/terraform-provider-aws/issues/19583 is resolved
+  tags = {
+    # Name = "${local.friendly_name_prefix}-sg-proxy-allow"
+    Name = "sg-proxy-allow"
+  }
+}
+
+resource "aws_security_group_rule" "proxy_ingress_mitmproxy" {
+  type        = "ingress"
+  from_port   = local.http_proxy_port
+  to_port     = local.http_proxy_port
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  description = "Allow TFE traffic to proxy instance"
+
+  security_group_id = aws_security_group.proxy.id
+}
+
+resource "aws_security_group_rule" "proxy_egress" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+  description = "Allow all egress traffic from proxy instance"
+
+  security_group_id = aws_security_group.proxy.id
+}
+
+resource "aws_iam_instance_profile" "proxy" {
+  name_prefix = "${local.friendly_name_prefix}-proxy"
+  role        = aws_iam_role.instance_role.name
+}
+
+resource "aws_iam_role" "instance_role" {
+  name_prefix        = "${local.friendly_name_prefix}-proxy"
+  assume_role_policy = data.aws_iam_policy_document.instance_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.instance_role.name
+  policy_arn = local.ssm_policy_arn
+}
+
+resource "aws_iam_role_policy" "secretsmanager" {
+  policy = data.aws_iam_policy_document.secretsmanager.json
+  role   = aws_iam_role.instance_role.id
+
+  name = "${local.friendly_name_prefix}-proxy-secretsmanager"
+}
+
+resource "aws_instance" "proxy" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "m4.xlarge"
+
+  iam_instance_profile = aws_iam_instance_profile.proxy.name
+  subnet_id            = module.tfe.private_subnet_ids[0]
+
+  vpc_security_group_ids = [
+    aws_security_group.proxy.id
+  ]
+
+  user_data = base64encode(
+    templatefile(
+      "${path.module}/templates/mitmproxy.sh.tpl",
+      {
+        certificate_secret = data.aws_secretsmanager_secret.ca_certificate
+        http_proxy_port    = local.http_proxy_port
+        private_key_secret = data.aws_secretsmanager_secret.ca_private_key
+      }
+    )
+  )
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "100"
+  }
+}

--- a/tests/active-active-rhel-proxy/templates/mitmproxy.sh.tpl
+++ b/tests/active-active-rhel-proxy/templates/mitmproxy.sh.tpl
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+apt-get --yes --option "Acquire::Retries=5" update
+apt-get install --yes unzip
+
+mkdir -p /etc/mitmproxy
+
+touch /etc/systemd/system/mitmproxy.service
+chown root:root /etc/systemd/system/mitmproxy.service
+chmod 0644 /etc/systemd/system/mitmproxy.service
+
+cat <<EOF >/etc/systemd/system/mitmproxy.service
+[Unit]
+Description=mitmproxy
+ConditionPathExists=/etc/mitmproxy
+[Service]
+ExecStart=/usr/local/bin/mitmdump -p ${http_proxy_port} --set confdir=/etc/mitmproxy --ssl-insecure
+Restart=always
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "[$(date +"%FT%T")]  Downloading mitmproxy tar from the web" | tee -a /var/log/ptfe.log
+curl -Lo /tmp/mitmproxy.tar.gz https://snapshots.mitmproxy.org/6.0.2/mitmproxy-6.0.2-linux.tar.gz
+tar xvf /tmp/mitmproxy.tar.gz -C /usr/local/bin/
+
+echo "[$(date +"%FT%T")] Installing JQ" | tee -a /var/log/ptfe.log
+curl --noproxy '*' -Lo /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+chmod +x /bin/jq
+
+echo "[$(date +"%FT%T")] Installing aws" | tee -a /var/log/ptfe.log
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+rm -f ./awscliv2.zip
+rm -rf ./aws
+
+echo "[$(date +"%FT%T")] Downloading Public Certificate and Private Key" | tee -a /var/log/ptfe.log
+# Obtain access token for Azure Key Vault
+certificate_data_b64=$(\
+  aws secretsmanager get-secret-value --secret-id ${certificate_secret.arn} \
+  | jq --raw-output '.SecretBinary,.SecretString | select(. != null)')
+key_data_b64=$(\
+  aws secretsmanager get-secret-value --secret-id ${private_key_secret.arn} \
+  | jq --raw-output '.SecretBinary,.SecretString | select(. != null)')
+
+echo "[$(date +"%FT%T")]  Deploying Public Certificate and Private Key for mitmproxy" | tee -a /var/log/ptfe.log
+cat <<EOF >/etc/mitmproxy/mitmproxy-ca.pem
+$(echo $certificate_data_b64 | base64 --decode)
+$(echo $key_data_b64 | base64 --decode)
+EOF
+
+echo "[$(date +"%FT%T")]  Starting mitmproxy service"
+systemctl daemon-reload
+systemctl start mitmproxy
+systemctl enable mitmproxy

--- a/tests/active-active-rhel-proxy/templates/ssh-config.tpl
+++ b/tests/active-active-rhel-proxy/templates/ssh-config.tpl
@@ -1,0 +1,11 @@
+Host default
+    HostName ${instance.id}
+    User ${user}
+    Port 22
+    UserKnownHostsFile /dev/null
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    IdentityFile ${identity_file}
+    IdentitiesOnly yes
+    LogLevel FATAL
+    ProxyCommand aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters "portNumber=%p"

--- a/tests/active-active-rhel-proxy/variables.tf
+++ b/tests/active-active-rhel-proxy/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_access_key_id" {
+  type        = string
+  description = "The identity of the access key which TFE will use to authenticate with S3."
+}
+
+variable "aws_secret_access_key" {
+  type        = string
+  description = "The secret access key which TFE will use to authenticate with S3."
+}
+
+# variable "aws_role_arn" {
+#   type        = string
+#   description = "The AWS Role ARN to assume for this module."
+# }
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "The ARN of an existing ACM certificate."
+}
+
+variable "license_file" {
+  type        = string
+  description = "The local path to the Terraform Enterprise license to be provided by CI."
+}
+
+variable "object_storage_iam_user_name" {
+  type        = string
+  description = "The name of the IAM user which will be authorized to access the S3 storage bucket."
+}

--- a/tests/active-active-rhel-proxy/variables.tf
+++ b/tests/active-active-rhel-proxy/variables.tf
@@ -8,10 +8,10 @@ variable "aws_secret_access_key" {
   description = "The secret access key which TFE will use to authenticate with S3."
 }
 
-# variable "aws_role_arn" {
-#   type        = string
-#   description = "The AWS Role ARN to assume for this module."
-# }
+variable "aws_role_arn" {
+  type        = string
+  description = "The AWS Role ARN to assume for this module."
+}
 
 variable "acm_certificate_arn" {
   type        = string

--- a/tests/active-active-rhel-proxy/versions.tf
+++ b/tests/active-active-rhel-proxy/versions.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.38"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.1"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.1"
+    }
+  }
+}

--- a/tests/private-tcp-active-active/templates/mitmproxy.sh.tpl
+++ b/tests/private-tcp-active-active/templates/mitmproxy.sh.tpl
@@ -2,6 +2,9 @@
 
 set -e -u -o pipefail
 
+echo "[$(date +"%FT%T")] Sleeping 30 seconds to let the network settle" | tee -a /var/log/ptfe.log
+sleep 30
+
 apt-get --yes --option "Acquire::Retries=5" update
 apt-get install --yes unzip
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,24 @@ variable "asg_tags" {
   default     = {}
 }
 
+variable "aws_access_key_id" {
+  default     = null
+  description = <<-EOD
+  The identity of the access key which TFE will use to authenticate with S3. This value requires var.
+  aws_secret_access_key to also be set. If this value is null then the IAM instance profile of the EC2 instance which
+  hosts will be used instead.
+  EOD
+  type        = string
+}
+
+variable "aws_secret_access_key" {
+  default     = null
+  description = <<-EOD
+  The secret access key which TFE will use to authenticate with S3. This value requires var.aws_secret_access_key to also be set.
+  EOD
+  type        = string
+}
+
 variable "redis_cache_size" {
   type        = string
   default     = "cache.m4.large"

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "aws_access_key_id" {
   default     = null
   description = <<-EOD
   The identity of the access key which TFE will use to authenticate with S3. This value requires var.
-  aws_secret_access_key and var.object_storage_iam_principal to also be set.
+  aws_secret_access_key and var.object_storage_iam_user to also be set.
   EOD
   type        = string
 }
@@ -34,12 +34,12 @@ variable "aws_secret_access_key" {
   default     = null
   description = <<-EOD
   The secret access key which TFE will use to authenticate with S3. This value requires var.aws_secret_access_key and
-  var.object_storage_iam_principal to also be set.
+  var.object_storage_iam_user to also be set.
   EOD
   type        = string
 }
 
-variable "object_storage_iam_principal" {
+variable "object_storage_iam_user" {
   default     = null
   description = <<-EOD
   The IAM user that will be authorized to access the S3 storage bucket which holds Terraform Enterprise runtime data.

--- a/variables.tf
+++ b/variables.tf
@@ -25,8 +25,7 @@ variable "aws_access_key_id" {
   default     = null
   description = <<-EOD
   The identity of the access key which TFE will use to authenticate with S3. This value requires var.
-  aws_secret_access_key to also be set. If this value is null then the IAM instance profile of the EC2 instance which
-  hosts will be used instead.
+  aws_secret_access_key and var.object_storage_iam_principal to also be set.
   EOD
   type        = string
 }
@@ -34,9 +33,20 @@ variable "aws_access_key_id" {
 variable "aws_secret_access_key" {
   default     = null
   description = <<-EOD
-  The secret access key which TFE will use to authenticate with S3. This value requires var.aws_secret_access_key to also be set.
+  The secret access key which TFE will use to authenticate with S3. This value requires var.aws_secret_access_key and
+  var.object_storage_iam_principal to also be set.
   EOD
   type        = string
+}
+
+variable "object_storage_iam_principal" {
+  default     = null
+  description = <<-EOD
+  The IAM user that will be authorized to access the S3 storage bucket which holds Terraform Enterprise runtime data.
+  This value requires var.aws_access_key_id and var.aws_secret_access_key to also be set. The values of those variables
+  must represent an access key that is associated with this user.
+  EOD
+  type        = object({ arn = string })
 }
 
 variable "redis_cache_size" {


### PR DESCRIPTION
## Background

This branch finishes the implementation for support of TFE using an access key to authenticate with S3, and also adds a new Active/Active RHEL Proxy test for TFE CI.

Because KMS is used to encrypt the S3 bucket (among other data sources), configuring TFE to use an access key for S3 access requires that the associated IAM user is also provided as an input so that it can be authorized to use the KMS key. This may be an indicator that the KMS key should not be managed within the module 🤔 


[Asana task](https://app.asana.com/0/1181500399442529/1201068889880717/f)


## How Has This Been Tested

I verified this branch with a local deployment as well as in [CI](https://circleci.com/gh/hashicorp/ptfe-replicated/18206?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

### Test Configuration

* Terraform Version: 1.0.10
* Any additional relevant variables:

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/5xtDarCDx7g6bl0SB44/giphy.gif?cid=5a38a5a280fmbnbfmn1ks68j34zwrlodv7kg7wczsqoyjojn&rid=giphy.gif&ct=g)
