### PR TITLE
Extend wait for TFE to 20 minutes in PTAA test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -531,7 +531,7 @@ jobs:
 
       - name: Wait For TFE
         id: wait-for-tfe
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |


### PR DESCRIPTION


## Background

This branch extends the Wait For TFE timeout to 20 minutes in the Private TCP Active/Active test.


[Recently failed timeout](https://github.com/hashicorp/terraform-aws-terraform-enterprise/runs/4168505195?check_suite_focus=true)


## How Has This Been Tested

It will be tested in #205 if we're unlucky :)


## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/myPdoRAlad0J2/giphy.gif?cid=5a38a5a2bvjum2bn0fpessp1r9b09ucalwhgbpyvfuwfe2nu&rid=giphy.gif&ct=g)
