### PR TITLE
mark output sensitive to pass CI

### DIFF
--- a/tests/active-active-rhel-proxy/outputs.tf
+++ b/tests/active-active-rhel-proxy/outputs.tf
@@ -1,6 +1,7 @@
 output "replicated_console_password" {
   value       = module.tfe.replicated_dashboard_password
   description = "The password for the TFE console"
+  sensitive   = true
 }
 
 output "replicated_console_url" {


### PR DESCRIPTION
## Background

I noticed the nightly failed due to the console password output not being marked as sensitive, so this just adds that.

Fixes this [failed Circle run](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2308/workflows/b7b1aa74-4c25-49b1-a101-af9bb42de096/jobs/18330)
