### PR TITLE
Correct zone name

### DIFF
--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  domain_name          = "tfe-team-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "ptfe-replicated.ptfedev.com"
+  domain_name          = "team-tfe-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  domain_name          = "ptfe-replicated.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -24,7 +24,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  domain_name          = "tfe-team-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -24,7 +24,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "ptfe-replicated.ptfedev.com"
+  domain_name          = "team-tfe-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -24,7 +24,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  domain_name          = "ptfe-replicated.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 


### PR DESCRIPTION
## Background

Somehow the created Route 53 zone and the domain name used in the modules got reversed, so I'm fixing it here. 

## How Has This Been Tested

This [Circle run](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2468/workflows/daec5196-5164-48cd-ab1c-9d9c85fdfc6c/jobs/18848) shows it working again.

## This PR makes me feel

![face palm](https://media.giphy.com/media/AjYsTtVxEEBPO/giphy.gif)
