### PR TITLE
revert the test domain_names back as the base infra was corrected

### DIFF
--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "tfe-team-dev.aws.ptfedev.com"
+  domain_name          = "team-tfe-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -24,7 +24,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "tfe-team-dev.aws.ptfedev.com"
+  domain_name          = "team-tfe-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 


### PR DESCRIPTION
## Background

I'm reversing this back because the run still fails since other resource (namely the certificate) were named the original way. This [PR to ptfedev-infra](https://github.com/hashicorp/ptfedev-infra/pull/329) corrects the problem only updating the route53 zone name.

These will be tested again in CircleCI once the above PR merges.