### PR TITLE
Fix references to CI AWS account

### DIFF
--- a/tests/active-active-rhel7-proxy/locals.tf
+++ b/tests/active-active-rhel7-proxy/locals.tf
@@ -3,7 +3,7 @@ locals {
 
   common_tags = {
     Terraform   = "cloud"
-    Environment = "team_tfe_dev"
+    Environment = "tfe_team_dev"
     Description = "Active/Active on RHEL with Proxy scenario deployed from CircleCI"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  domain_name          = "tfe-team-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -24,7 +24,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn  = var.acm_certificate_arn
-  domain_name          = "team-tfe-dev.aws.ptfedev.com"
+  domain_name          = "tfe-team-dev.aws.ptfedev.com"
   friendly_name_prefix = local.friendly_name_prefix
   tfe_license_secret   = aws_secretsmanager_secret.tfe_license
 


### PR DESCRIPTION
\#\# Background

This branch corrects references and tags for resources created in the tfe\_team\_dev account.

Relates https://github.com/hashicorp/ptfedev\-infra/pull/330


\#\# How Has This Been Tested

~It shall be tested here.~ It will be tested in CI.

\#\# This PR makes me feel

\!\[optional gif describing your feelings about this pr\]\(https://media3.giphy.com/media/Wt6kNaMjofj1jHkF7t/giphy.gif?cid=5a38a5a2c003kej8cv64l63pfwgveq4qfigi4209whhbnidw&rid=giphy.gif&ct=g\)
