### PR TITLE
Upgrade standalone-vault to vault ~> 3.1

### DIFF
--- a/tests/standalone-vault/versions.tf
+++ b/tests/standalone-vault/versions.tf
@@ -15,7 +15,7 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "2.24.1"
+      version = "~> 3.1"
     }
   }
 }


### PR DESCRIPTION
## Background

The [latest nightly build](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2588/workflows/9ddee2bd-b25c-4118-b1ff-5a360ad1c274/jobs/19203) failed the standalone-vault scenario with the following error:
> ╷
> │ Error: unknown type <nil> for cidr_list in response for SecretID "60b61200-0b41-209f-c95b-e4656eb3dd99"
> │ 
> │   with vault_approle_auth_backend_role_secret_id.approle,
> │   on vault.tf line 70, in resource "vault_approle_auth_backend_role_secret_id" "approle":
> │   70: resource "vault_approle_auth_backend_role_secret_id" "approle" {
> │ 
> ╵
This issue was fixed with vault provider [3.0.1](https://github.com/hashicorp/terraform-provider-vault/blob/main/CHANGELOG.md#301-november-23-2021). This branch upgrades the vault provider in the standalone-vault test from 2.24.1 to ~> 3.1. It appears that there were no breaking changes that affect our usage with version 3 so this should be a safe upgrade without additional changes.

## How Has This Been Tested

The nightly will be rerun.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/l0G17R0PwQRo0PFrG/giphy.gif?cid=5a38a5a2yplq81wq9p5lgdwa96nuvhq0lb6ct77cg2k5a2dx&rid=giphy.gif&ct=g)
