### PR TITLE
Remove test logic to handle untrusted certificates

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -537,7 +537,6 @@ jobs:
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \
-            --insecure \
             --connect-timeout 10 \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \
             $HEALTH_CHECK_URL; \
@@ -562,7 +561,6 @@ jobs:
         run: |
           token=$( \
             curl --fail --retry 5 --verbose \
-            --insecure \
             --connect-timeout 10 \
             --proxy socks5://localhost:5000 "$IACT_URL")
           echo "::set-output name=token::$token"
@@ -585,7 +583,6 @@ jobs:
             > ./payload.json
           response=$( \
             curl \
-            --insecure \
             --connect-timeout 10 \
             --fail \
             --retry 5 \
@@ -612,7 +609,6 @@ jobs:
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
           TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
           TFE_EMAIL: tf-onprem-team@hashicorp.com
-          TFE_SKIP_TLS_VERIFY: "true"
           http_proxy: socks5://localhost:5000/
           https_proxy: socks5://localhost:5000/
         run: |


### PR DESCRIPTION
## Background

This PR updates the test jobs to not ignore untrusted TLS certificates, as the backend infrastructure has been updated to use publicly trusted certificates.


Relates https://app.asana.com/0/1135304898243667/1201128036677602/f


## How Has This Been Tested

This logic will be tested here, post-merge.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/W6ijtBmn4RImWFmfM1/giphy.gif?cid=5a38a5a2wz6bpssz3dpv4r73txj33fcxoezz8xcy82tnojlj&rid=giphy.gif&ct=g)
