### PR TITLE
Make curl verbose while waiting for TFE

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -539,6 +539,7 @@ jobs:
           while ! curl \
             --connect-timeout 10 \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \
+            --verbose \
             $HEALTH_CHECK_URL; \
             do sleep 5; done
 


### PR DESCRIPTION
## Background

This PR updates the Private TCP Active/Active Wait For TFE logic to make curl verbose in order to debug the certificate received from the health check URL.

Relates #214


## How Has This Been Tested

It will be tested in #214.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/h5sUWhla9FlJizxha9/giphy.gif?cid=5a38a5a25v88ng1muc76qfxuws90ad6uia5l65dhh2p79gd8&rid=giphy.gif&ct=g)
