### PR TITLE
Revert "Remove logic to handle untrusted certificates (#214)"

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -537,6 +537,7 @@ jobs:
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
           while ! curl \
+            --insecure \
             --connect-timeout 10 \
             -sfS --max-time 5 --proxy socks5://localhost:5000 \
             --verbose \
@@ -562,6 +563,7 @@ jobs:
         run: |
           token=$( \
             curl --fail --retry 5 --verbose \
+            --insecure \
             --connect-timeout 10 \
             --proxy socks5://localhost:5000 "$IACT_URL")
           echo "::set-output name=token::$token"
@@ -584,6 +586,7 @@ jobs:
             > ./payload.json
           response=$( \
             curl \
+            --insecure \
             --connect-timeout 10 \
             --fail \
             --retry 5 \
@@ -610,6 +613,7 @@ jobs:
           TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
           TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
           TFE_EMAIL: tf-onprem-team@hashicorp.com
+          TFE_SKIP_TLS_VERIFY: "true"
           http_proxy: socks5://localhost:5000/
           https_proxy: socks5://localhost:5000/
         run: |


### PR DESCRIPTION
## Background

This PR reverts #214 as the [necessary Replicated TLS settings](https://app.asana.com/0/1200681690870921/1201652182309957/f) are not yet in place.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/l2Je3KZjdL5k7BWiQ/giphy.gif?cid=5a38a5a2rj6rwaj683eujqb7ps6u8rfrzvbgnui88g974ou0&rid=giphy.gif&ct=g)
