### PR TITLE
Add name tag to default security group

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -29,6 +29,10 @@ module "vpc" {
   single_nat_gateway             = false
 
   # Prefixes removed until https://github.com/hashicorp/terraform-provider-aws/issues/19583 is resolved
+  default_security_group_tags = {
+    # Name = "${var.friendly_name_prefix}-tfe-dsg"
+    Name = "tfe-dsg"
+  }
   igw_tags = {
     # Name = "${var.friendly_name_prefix}-tfe-igw"
     Name = "tfe-igw"


### PR DESCRIPTION
## Background

This PR adds a Name tag to the default security group created by the `terraform-aws-modules/vpc` module in order to work around the following error:

When expanding the plan for module.tfe.module.networking[0].module.vpc.aws_default_security_group.this[0] to include new values learned so far during apply, provider "registry.terraform.io/hashicorp/aws" produced an invalid new value for .tags_all: new element "Name" has appeared.

Note for posterity: modules from `terraform-aws-modules` make a lot of assumptions that don't align well with our use cases (both here and internally). We should look at removing them to avoid more valueless toil in the future.

## How Has This Been Tested

It shall be tested here, live!

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/3o6Mb5Cy5tZFkNLLLa/giphy.gif?cid=5a38a5a2gz5tjnmak1vrc45ywu8vuizy11g97q2sea07g981&rid=giphy.gif&ct=g)
