### PR TITLE
Add prefixes to test secret names

### DIFF
--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -8,7 +8,7 @@ resource "random_string" "friendly_name" {
 module "secrets" {
   source = "../../fixtures/secrets"
   tfe_license = {
-    name = "my-tfe-license"
+    name = "${local.friendly_name_prefix}-tfe-license"
     path = var.license_file
   }
 }

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -13,12 +13,12 @@ resource "random_string" "friendly_name" {
 module "secrets" {
   source = "../../fixtures/secrets"
   tfe_license = {
-    name = "my-tfe-license"
+    name = "${local.friendly_name_prefix}-tfe-license"
     path = var.license_file
   }
 }
 # Standalone, external services with external (HCP) Vault scenario
-# ---------------------------------------------------------------- 
+# ----------------------------------------------------------------
 module "standalone_vault" {
   source = "../../"
 


### PR DESCRIPTION
## Background

This PR adds the "friendly name prefix" to the license secrets created in the tests active-active-rhel7-proxy and standalone-vault, as the secret names can not be reused until AWS purges the original secrets.


Relates https://github.com/hashicorp/ptfe-replicated/pull/925


## How Has This Been Tested

We will rerun the nightly post-merge.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/3orieV94MAL3OLlOAU/giphy.gif?cid=5a38a5a26yd2dsm23f3sfv3827w76jlvjuyq4h4ffoln1oy5&rid=giphy.gif&ct=g)
