### PR TITLE
fix

### DIFF
--- a/examples/standalone-mounted/main.tf
+++ b/examples/standalone-mounted/main.tf
@@ -33,7 +33,7 @@ resource "aws_key_pair" "main" {
 module "secrets" {
   source = "../../fixtures/secrets"
   tfe_license = {
-    name = "tfe-license"
+    name = "${var.friendly_name_prefix}-license"
     path = var.license_file
   }
 }


### PR DESCRIPTION
## Background

fix for error on license : 

Error: error creating Secrets Manager Secret: InvalidRequestException: You can't create this secret because a secret with this name is already scheduled for deletion.
│ 
│   with module.secrets.aws_secretsmanager_secret.tfe_license[0],
│   on ../../fixtures/secrets/main.tf line 1, in resource "aws_secretsmanager_secret" "tfe_license":
│    1: resource "aws_secretsmanager_secret" "tfe_license" {
│ 

