### PR TITLE
Add secrets to secrets fixture module

### DIFF
--- a/fixtures/secrets/README.md
+++ b/fixtures/secrets/README.md
@@ -12,7 +12,11 @@ non-null values.
 
 module "secrets" {
   source = "./fixtures/secrets"
-  license_file = var.license_file
+
+  tfe_license = {
+    name = "${var.friendly_name_prefix}-license"
+    path = var.license_file
+  }
 }
 
 ```

--- a/fixtures/secrets/main.tf
+++ b/fixtures/secrets/main.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "tfe_license" {
   count       = var.tfe_license == null ? 0 : 1
   name        = var.tfe_license.name
-  description = "The TFE license."
+  description = "The TFE license"
 }
 
 resource "aws_secretsmanager_secret_version" "tfe_license" {
@@ -12,24 +12,48 @@ resource "aws_secretsmanager_secret_version" "tfe_license" {
 
 resource "aws_secretsmanager_secret" "ca_certificate_secret" {
   count       = var.ca_certificate_secret == null ? 0 : 1
-  name        = "ca_certificate_secret"
+  name        = var.ca_certificate_secret.name
   description = "The CA certificate"
 }
 
 resource "aws_secretsmanager_secret_version" "ca_certificate_secret" {
   count         = var.ca_certificate_secret == null ? 0 : 1
-  secret_binary = base64encode(var.ca_certificate_secret)
+  secret_binary = base64encode(var.ca_certificate_secret.data)
   secret_id     = aws_secretsmanager_secret.ca_certificate_secret[count.index].id
 }
 
-resource "aws_secretsmanager_secret" "ca_private_key" {
-  name        = var.ca_private_key.id
-  count       = var.ca_private_key == null ? 0 : 1
+resource "aws_secretsmanager_secret" "ca_private_key_secret" {
+  count       = var.ca_private_key_secret == null ? 0 : 1
+  name        = var.ca_private_key_secret.name
   description = "CA Certificate private key"
 }
 
-resource "aws_secretsmanager_secret_version" "ca_private_key" {
-  count         = var.ca_private_key == null ? 0 : 1
-  secret_binary = base64encode(var.ca_private_key.data)
-  secret_id     = aws_secretsmanager_secret.ca_private_key[count.index].id
+resource "aws_secretsmanager_secret_version" "ca_private_key_secret" {
+  count         = var.ca_private_key_secret == null ? 0 : 1
+  secret_binary = base64encode(var.ca_private_key_secret.data)
+  secret_id     = aws_secretsmanager_secret.ca_private_key_secret[count.index].id
+}
+
+resource "aws_secretsmanager_secret" "certificate_pem_secret" {
+  count       = var.certificate_pem_secret == null ? 0 : 1
+  name        = var.certificate_pem_secret.name
+  description = "The PEM-encoded TLS certificate"
+}
+
+resource "aws_secretsmanager_secret_version" "certificate_pem_secret" {
+  count         = var.certificate_pem_secret == null ? 0 : 1
+  secret_binary = base64encode(var.certificate_pem_secret.data)
+  secret_id     = aws_secretsmanager_secret.certificate_pem_secret[count.index].id
+}
+
+resource "aws_secretsmanager_secret" "private_key_pem_secret" {
+  count       = var.private_key_pem_secret == null ? 0 : 1
+  name        = var.private_key_pem_secret.name
+  description = "The PEM-encoded TLS private key"
+}
+
+resource "aws_secretsmanager_secret_version" "private_key_pem_secret" {
+  count         = var.private_key_pem_secret == null ? 0 : 1
+  secret_binary = base64encode(var.private_key_pem_secret.data)
+  secret_id     = aws_secretsmanager_secret.private_key_pem_secret[count.index].id
 }

--- a/fixtures/secrets/output.tf
+++ b/fixtures/secrets/output.tf
@@ -6,6 +6,14 @@ output "ca_certificate_secret_id" {
   value = var.ca_certificate_secret == null ? null : aws_secretsmanager_secret_version.ca_certificate_secret[0].secret_id
 }
 
-output "ca_private_key" {
-  value = var.ca_private_key == null ? null : aws_secretsmanager_secret_version.ca_private_key[0].secret_id
+output "ca_private_key_secret_id" {
+  value = var.ca_private_key_secret == null ? null : aws_secretsmanager_secret_version.ca_private_key_secret[0].secret_id
+}
+
+output "certificate_pem_secret_id" {
+  value = var.certificate_pem_secret == null ? null : aws_secretsmanager_secret_version.certificate_pem_secret[0].secret_id
+}
+
+output "private_key_pem_secret_id" {
+  value = var.private_key_pem_secret == null ? null : aws_secretsmanager_secret_version.private_key_pem_secret[0].secret_id
 }

--- a/fixtures/secrets/variables.tf
+++ b/fixtures/secrets/variables.tf
@@ -10,14 +10,35 @@ variable "tfe_license" {
 variable "ca_certificate_secret" {
   default     = null
   description = "The secret identifier and data of a PEM certificate file for a Certificate Authority."
-  type        = string
+  type = object({
+    name = string
+    data = string
+  })
 }
 
-variable "ca_private_key" {
+variable "ca_private_key_secret" {
   default     = null
   description = "The secret identifier and data of a PEM private key file for a Certificate Authority."
   type = object({
-    id   = string
+    name = string
+    data = string
+  })
+}
+
+variable "certificate_pem_secret" {
+  default     = null
+  description = "The secret identifier and data of a PEM certificate file for a TLS."
+  type = object({
+    name = string
+    data = string
+  })
+}
+
+variable "private_key_pem_secret" {
+  default     = null
+  description = "The secret identifier and data of a PEM private key file for a TLS."
+  type = object({
+    name = string
     data = string
   })
 }


### PR DESCRIPTION
## Background

This branch adds secrets to the fixtures/secrets modules for upcoming changes that will include adding TLS certificates to the TFE instance.

Asana: https://app.asana.com/0/1181500399442529/1201652182309957/f

## How Has This Been Tested

This config is currently not consumed anywhere, therefore, it will be tested when I add it to the ptfedev-infra module in place of [this config](https://github.com/hashicorp/ptfedev-infra/blob/master/aws-test/secrets.tf).

## This PR makes me feel

![secrets](https://media.giphy.com/media/SWFKjmZNMsLP3JoeWm/giphy.gif)
