### PR TITLE
output fixture/secrets with objects

### DIFF
--- a/fixtures/secrets/output.tf
+++ b/fixtures/secrets/output.tf
@@ -22,7 +22,7 @@ output "ca_private_key_secret" {
     name      = aws_secretsmanager_secret_version.ca_private_key_secret[0].name
     secret_id = aws_secretsmanager_secret_version.ca_private_key_secret[0].secret_id
   }
-  description = "The AWS Secrets Manager secret which will be used for the ca_private_key_secret variable in the test modules."
+  description = "The AWS Secrets Manager secret which will be used for the ca_private_key_secret_id variable in the test modules."
   sensitive   = true
 }
 


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202037504110362/f 
Relates #230

As I was about to add the outputs of these secrets to create variables for the `aws-test` workspaces, I realized that I needed the secret names in the output, too, because I'd like for them to correlate with the variable names.

## How Has This Been Tested

Again, these secrets and outputs are not yet in use anywhere, so they'll be tested when I use them in the ptfedev-infra/aws-test module. 

## This PR makes me feel

![I was wrong](https://media.giphy.com/media/TgnAf2rrHKGkvI41uS/giphy.gif)
