### PR TITLE
add tls key/cert to TFE

### DIFF
--- a/fixtures/test_proxy/data.tf
+++ b/fixtures/test_proxy/data.tf
@@ -41,10 +41,10 @@ data "aws_iam_policy_document" "secretsmanager" {
 
 data "aws_secretsmanager_secret" "ca_certificate" {
   count = local.mitmproxy_selected ? 1 : 0
-  name  = var.mitmproxy_ca_certificate_secret
+  arn   = var.mitmproxy_ca_certificate_secret
 }
 
 data "aws_secretsmanager_secret" "ca_private_key" {
   count = local.mitmproxy_selected ? 1 : 0
-  name  = var.mitmproxy_ca_private_key_secret
+  arn   = var.mitmproxy_ca_private_key_secret
 }

--- a/fixtures/test_proxy/data.tf
+++ b/fixtures/test_proxy/data.tf
@@ -41,10 +41,10 @@ data "aws_iam_policy_document" "secretsmanager" {
 
 data "aws_secretsmanager_secret" "ca_certificate" {
   count = local.mitmproxy_selected ? 1 : 0
-  arn   = var.mitmproxy_ca_certificate_secret
+  name  = var.mitmproxy_ca_certificate_secret
 }
 
 data "aws_secretsmanager_secret" "ca_private_key" {
   count = local.mitmproxy_selected ? 1 : 0
-  arn   = var.mitmproxy_ca_private_key_secret
+  name  = var.mitmproxy_ca_private_key_secret
 }

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,8 @@ module "service_accounts" {
   iam_role_policy_arns     = var.iam_role_policy_arns
   tfe_license_secret_id    = var.tfe_license_secret_id
   kms_key_arn              = local.kms_key_arn
+  vm_certificate_secret_id = var.vm_certificate_secret_id
+  vm_key_secret_id         = var.vm_key_secret_id
 }
 
 # -----------------------------------------------------------------------------

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -1,3 +1,8 @@
 locals {
-  secret_arns = [for secret in [var.ca_certificate_secret_id, var.tfe_license_secret_id] : secret if secret != null]
+  secret_arns = [for secret in [
+    var.ca_certificate_secret_id,
+    var.tfe_license_secret_id,
+    var.vm_certificate_secret_id,
+    var.vm_key_secret_id
+  ] : secret if secret != null]
 }

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -26,3 +26,21 @@ variable "kms_key_arn" {
   type        = string
   description = "KMS key arn for AWS KMS Customer managed key."
 }
+
+variable "vm_certificate_secret_id" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  A Secrets Manager secret ARN which contains the Base64 encoded version of a PEM encoded public certificate for the Virtual
+  Machine Scale Set.
+  EOD
+}
+
+variable "vm_key_secret_id" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  A Secrets Manager secret ARN which contains the Base64 encoded version of a PEM encoded private key for the Virtual Machine
+  Scale Set.
+  EOD
+}

--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -1,15 +1,3 @@
-data "aws_secretsmanager_secret" "tfe_license" {
-  name = var.tfe_license_secret_name
-}
-
-data "aws_secretsmanager_secret" "certificate_pem" {
-  name = var.certificate_pem_secret_name
-}
-
-data "aws_secretsmanager_secret" "private_key_pem" {
-  name = var.private_key_pem_secret_name
-}
-
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -2,6 +2,14 @@ data "aws_secretsmanager_secret" "tfe_license" {
   name = var.tfe_license_secret_name
 }
 
+data "aws_secretsmanager_secret" "certificate_pem" {
+  name = var.certificate_pem_secret_name
+}
+
+data "aws_secretsmanager_secret" "private_key_pem" {
+  name = var.private_key_pem_secret_name
+}
+
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -34,7 +34,7 @@ module "private_active_active" {
   acm_certificate_arn   = var.acm_certificate_arn
   domain_name           = var.domain_name
   friendly_name_prefix  = local.friendly_name_prefix
-  tfe_license_secret_id = data.aws_secretsmanager_secret.tfe_license.arn
+  tfe_license_secret_id = var.tfe_license_secret_id
 
   ami_id                      = data.aws_ami.rhel.id
   distribution                = "rhel"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -51,10 +51,6 @@ module "private_active_active" {
   redis_encryption_in_transit = true
   redis_use_password_auth     = true
   tfe_subdomain               = local.test_name
-  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.certificate_pem_secret_id
-  vm_key_secret_id            = var.private_key_pem_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -53,8 +53,8 @@ module "private_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.certificate_secret_id
-  vm_key_secret_id            = var.key_secret_id
+  vm_certificate_secret_id    = var.certificate_pem_secret_id
+  vm_key_secret_id            = var.private_key_pem_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -53,8 +53,8 @@ module "private_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.vm_certificate_secret_id
-  vm_key_secret_id            = var.vm_key_secret_id
+  vm_certificate_secret_id    = var.certificate_secret_id
+  vm_key_secret_id            = var.key_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -53,8 +53,8 @@ module "private_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = data.aws_secretsmanager_secret.certificate_pem.arn
-  vm_key_secret_id            = data.aws_secretsmanager_secret.private_key_pem.arn
+  vm_certificate_secret_id    = var.vm_certificate_secret_id
+  vm_key_secret_id            = var.vm_key_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -51,6 +51,10 @@ module "private_active_active" {
   redis_encryption_in_transit = true
   redis_use_password_auth     = true
   tfe_subdomain               = local.test_name
+  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
+  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
+  vm_certificate_secret_id    = data.aws_secretsmanager_secret.certificate_pem.arn
+  vm_key_secret_id            = data.aws_secretsmanager_secret.private_key_pem.arn
 
   asg_tags = local.common_tags
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -18,19 +18,17 @@ variable "key_name" {
   type        = string
 }
 
-variable "tfe_license_secret_name" {
+variable "tfe_license_secret_id" {
   type        = string
-  description = <<-EOD
-  The name of the Secrets Manager secret under which the Base64 encoded Terraform Enterprise license is stored.
-  EOD
+  description = "The secrets manager secret ID of the Base64 encoded Terraform Enterprise license."
 }
 
-variable "certificate_pem_secret_name" {
+variable "certificate_pem_secret_id" {
   type        = string
-  description = "The secrets manager secret name of the Base64 & PEM encoded TLS certificate."
+  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
 }
 
-variable "private_key_pem_secret_name" {
+variable "private_key_pem_secret_id" {
   type        = string
-  description = "The secrets manager secret name under which the Base64 & PEM encoded TLS private key."
+  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS private key."
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -22,13 +22,3 @@ variable "tfe_license_secret_id" {
   type        = string
   description = "The secrets manager secret ID of the Base64 encoded Terraform Enterprise license."
 }
-
-variable "certificate_pem_secret_id" {
-  type        = string
-  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
-}
-
-variable "private_key_pem_secret_id" {
-  type        = string
-  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS private key."
-}

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -24,3 +24,13 @@ variable "tfe_license_secret_name" {
   The name of the Secrets Manager secret under which the Base64 encoded Terraform Enterprise license is stored.
   EOD
 }
+
+variable "certificate_pem_secret_name" {
+  type        = string
+  description = "The secrets manager secret name of the Base64 & PEM encoded TLS certificate."
+}
+
+variable "private_key_pem_secret_name" {
+  type        = string
+  description = "The secrets manager secret name under which the Base64 & PEM encoded TLS private key."
+}

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -10,6 +10,14 @@ data "aws_secretsmanager_secret" "tfe_license" {
   name = var.tfe_license_secret_name
 }
 
+data "aws_secretsmanager_secret" "certificate_pem" {
+  name = var.certificate_pem_secret_name
+}
+
+data "aws_secretsmanager_secret" "private_key_pem" {
+  name = var.private_key_pem_secret_name
+}
+
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -1,3 +1,11 @@
+data "aws_secretsmanager_secret" "ca_certificate" {
+  name = var.ca_certificate_secret_name
+}
+
+data "aws_secretsmanager_secret" "ca_private_key" {
+  name = var.ca_private_key_secret_name
+}
+
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -1,23 +1,3 @@
-data "aws_secretsmanager_secret" "ca_certificate" {
-  name = var.ca_certificate_secret_name
-}
-
-data "aws_secretsmanager_secret" "ca_private_key" {
-  name = var.ca_private_key_secret_name
-}
-
-data "aws_secretsmanager_secret" "tfe_license" {
-  name = var.tfe_license_secret_name
-}
-
-data "aws_secretsmanager_secret" "certificate_pem" {
-  name = var.certificate_pem_secret_name
-}
-
-data "aws_secretsmanager_secret" "private_key_pem" {
-  name = var.private_key_pem_secret_name
-}
-
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -56,8 +56,8 @@ module "private_tcp_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = data.aws_secretsmanager_secret.certificate_pem.arn
-  vm_key_secret_id            = data.aws_secretsmanager_secret.private_key_pem.arn
+  vm_certificate_secret_id    = var.vm_certificate_secret_id
+  vm_key_secret_id            = var.vm_key_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -56,8 +56,8 @@ module "private_tcp_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.vm_certificate_secret_id
-  vm_key_secret_id            = var.vm_key_secret_id
+  vm_certificate_secret_id    = var.certificate_secret_id
+  vm_key_secret_id            = var.key_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -54,6 +54,10 @@ module "private_tcp_active_active" {
   redis_encryption_in_transit = true
   redis_use_password_auth     = true
   tfe_subdomain               = local.test_name
+  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
+  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
+  vm_certificate_secret_id    = data.aws_secretsmanager_secret.certificate_pem.arn
+  vm_key_secret_id            = data.aws_secretsmanager_secret.private_key_pem.arn
 
   asg_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -41,7 +41,7 @@ module "private_tcp_active_active" {
 
   ami_id                      = data.aws_ami.rhel.id
   distribution                = "rhel"
-  ca_certificate_secret_id    = var.ca_certificate_secret_id
+  ca_certificate_secret_id    = data.aws_secretsmanager_secret.ca_certificate.arn
   iact_subnet_list            = ["0.0.0.0/0"]
   iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.8xlarge"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -25,8 +25,8 @@ module "test_proxy" {
   subnet_id                       = module.private_tcp_active_active.private_subnet_ids[0]
   name                            = local.friendly_name_prefix
   key_name                        = var.key_name
-  mitmproxy_ca_certificate_secret = data.aws_secretsmanager_secret.ca_certificate.arn
-  mitmproxy_ca_private_key_secret = data.aws_secretsmanager_secret.ca_private_key.arn
+  mitmproxy_ca_certificate_secret = var.ca_certificate_secret_id
+  mitmproxy_ca_private_key_secret = var.ca_private_key_secret_id
   vpc_id                          = module.private_tcp_active_active.network_id
 
 }
@@ -37,11 +37,11 @@ module "private_tcp_active_active" {
   acm_certificate_arn   = var.acm_certificate_arn
   domain_name           = var.domain_name
   friendly_name_prefix  = local.friendly_name_prefix
-  tfe_license_secret_id = data.aws_secretsmanager_secret.tfe_license.arn
+  tfe_license_secret_id = var.tfe_license_secret_id
 
   ami_id                      = data.aws_ami.rhel.id
   distribution                = "rhel"
-  ca_certificate_secret_id    = data.aws_secretsmanager_secret.ca_certificate.arn
+  ca_certificate_secret_id    = var.ca_certificate_secret_id
   iact_subnet_list            = ["0.0.0.0/0"]
   iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.8xlarge"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -25,8 +25,8 @@ module "test_proxy" {
   subnet_id                       = module.private_tcp_active_active.private_subnet_ids[0]
   name                            = local.friendly_name_prefix
   key_name                        = var.key_name
-  mitmproxy_ca_certificate_secret = var.ca_certificate_secret_id
-  mitmproxy_ca_private_key_secret = var.ca_private_key_secret_id
+  mitmproxy_ca_certificate_secret = var.ca_certificate_secret_name
+  mitmproxy_ca_private_key_secret = var.ca_private_key_secret_name
   vpc_id                          = module.private_tcp_active_active.network_id
 
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -25,8 +25,8 @@ module "test_proxy" {
   subnet_id                       = module.private_tcp_active_active.private_subnet_ids[0]
   name                            = local.friendly_name_prefix
   key_name                        = var.key_name
-  mitmproxy_ca_certificate_secret = var.ca_certificate_secret_name
-  mitmproxy_ca_private_key_secret = var.ca_private_key_secret_name
+  mitmproxy_ca_certificate_secret = data.aws_secretsmanager_secret.ca_certificate.arn
+  mitmproxy_ca_private_key_secret = data.aws_secretsmanager_secret.ca_private_key.arn
   vpc_id                          = module.private_tcp_active_active.network_id
 
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -56,8 +56,8 @@ module "private_tcp_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.certificate_secret_id
-  vm_key_secret_id            = var.key_secret_id
+  vm_certificate_secret_id    = var.certificate_pem_secret_id
+  vm_key_secret_id            = var.private_key_pem_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -23,14 +23,14 @@ variable "tfe_license_secret_id" {
   description = "The secrets manager secret ID of the Base64 encoded Terraform Enterprise license."
 }
 
-variable "ca_certificate_secret_id" {
+variable "ca_certificate_secret_name" {
   type        = string
-  description = "The secrets manager secret ID of the Base64 encoded CA certificate."
+  description = "The secrets manager secret name of the Base64 encoded CA certificate."
 }
 
-variable "ca_private_key_secret_id" {
+variable "ca_private_key_secret_name" {
   type        = string
-  description = "The secrets manager secret ID of the Base64 encoded CA private key."
+  description = "The secrets manager secret name of the Base64 encoded CA private key."
 }
 
 variable "certificate_pem_secret_id" {

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -18,33 +18,27 @@ variable "key_name" {
   type        = string
 }
 
-variable "tfe_license_secret_name" {
+variable "tfe_license_secret_id" {
   type        = string
-  description = <<-EOD
-  The name of the Secrets Manager secret under which the Base64 encoded Terraform Enterprise license is stored.
-  EOD
+  description = "The secrets manager secret ID of the Base64 encoded Terraform Enterprise license."
 }
 
-variable "ca_certificate_secret_name" {
+variable "ca_certificate_secret_id" {
   type        = string
-  description = <<-EOD
-  The name of the Secrets Manager secret under which the Base64 encoded CA certificate is stored.
-  EOD
+  description = "The secrets manager secret ID of the Base64 encoded CA certificate."
 }
 
-variable "ca_private_key_secret_name" {
+variable "ca_private_key_secret_id" {
   type        = string
-  description = <<-EOD
-  The name of the Secrets Manager secret under which the Base64 encoded CA private key is stored.
-  EOD
+  description = "The secrets manager secret ID of the Base64 encoded CA private key."
 }
 
-variable "certificate_pem_secret_name" {
+variable "certificate_pem_secret_id" {
   type        = string
-  description = "The secrets manager secret name of the Base64 & PEM encoded TLS certificate."
+  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
 }
 
-variable "private_key_pem_secret_name" {
+variable "private_key_pem_secret_id" {
   type        = string
-  description = "The secrets manager secret name under which the Base64 & PEM encoded TLS private key."
+  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS private key."
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -38,3 +38,13 @@ variable "ca_private_key_secret_name" {
   The name of the Secrets Manager secret under which the Base64 encoded CA private key is stored.
   EOD
 }
+
+variable "certificate_pem_secret_name" {
+  type        = string
+  description = "The secrets manager secret name of the Base64 & PEM encoded TLS certificate."
+}
+
+variable "private_key_pem_secret_name" {
+  type        = string
+  description = "The secrets manager secret name under which the Base64 & PEM encoded TLS private key."
+}

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -2,6 +2,14 @@ data "aws_secretsmanager_secret" "tfe_license" {
   name = var.tfe_license_secret_name
 }
 
+data "aws_secretsmanager_secret" "certificate_pem" {
+  name = var.certificate_pem_secret_name
+}
+
+data "aws_secretsmanager_secret" "private_key_pem" {
+  name = var.private_key_pem_secret_name
+}
+
 data "aws_ami" "ubuntu" {
   most_recent = true
 

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -1,15 +1,3 @@
-data "aws_secretsmanager_secret" "tfe_license" {
-  name = var.tfe_license_secret_name
-}
-
-data "aws_secretsmanager_secret" "certificate_pem" {
-  name = var.certificate_pem_secret_name
-}
-
-data "aws_secretsmanager_secret" "private_key_pem" {
-  name = var.private_key_pem_secret_name
-}
-
 data "aws_ami" "ubuntu" {
   most_recent = true
 

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -26,7 +26,7 @@ module "public_active_active" {
   acm_certificate_arn   = var.acm_certificate_arn
   domain_name           = var.domain_name
   friendly_name_prefix  = local.friendly_name_prefix
-  tfe_license_secret_id = data.aws_secretsmanager_secret.tfe_license.arn
+  tfe_license_secret_id = var.tfe_license_secret_id
   distribution          = "ubuntu"
 
   ami_id                      = data.aws_ami.ubuntu.id

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -43,8 +43,8 @@ module "public_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.certificate_secret_id
-  vm_key_secret_id            = var.key_secret_id
+  vm_certificate_secret_id    = var.certificate_pem_secret_id
+  vm_key_secret_id            = var.private_key_pem_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -43,8 +43,8 @@ module "public_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.vm_certificate_secret_id
-  vm_key_secret_id            = var.vm_key_secret_id
+  vm_certificate_secret_id    = var.certificate_secret_id
+  vm_key_secret_id            = var.key_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -43,8 +43,8 @@ module "public_active_active" {
   tfe_subdomain               = local.test_name
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = data.aws_secretsmanager_secret.certificate_pem.arn
-  vm_key_secret_id            = data.aws_secretsmanager_secret.private_key_pem.arn
+  vm_certificate_secret_id    = var.vm_certificate_secret_id
+  vm_key_secret_id            = var.vm_key_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -41,10 +41,6 @@ module "public_active_active" {
   redis_encryption_in_transit = false
   redis_use_password_auth     = false
   tfe_subdomain               = local.test_name
-  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.certificate_pem_secret_id
-  vm_key_secret_id            = var.private_key_pem_secret_id
 
   asg_tags = local.common_tags
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -41,6 +41,10 @@ module "public_active_active" {
   redis_encryption_in_transit = false
   redis_use_password_auth     = false
   tfe_subdomain               = local.test_name
+  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
+  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
+  vm_certificate_secret_id    = data.aws_secretsmanager_secret.certificate_pem.arn
+  vm_key_secret_id            = data.aws_secretsmanager_secret.private_key_pem.arn
 
   asg_tags = local.common_tags
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -30,3 +30,13 @@ variable "tfe_license_secret_name" {
   The name of the Secrets Manager secret under which the Base64 encoded Terraform Enterprise license is stored.
   EOD
 }
+
+variable "certificate_pem_secret_name" {
+  type        = string
+  description = "The secrets manager secret name of the Base64 & PEM encoded TLS certificate."
+}
+
+variable "private_key_pem_secret_name" {
+  type        = string
+  description = "The secrets manager secret name under which the Base64 & PEM encoded TLS private key."
+}

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -30,13 +30,3 @@ variable "tfe_license_secret_id" {
   The name of the Secrets Manager secret ID of the Base64 encoded Terraform Enterprise license.
   EOD
 }
-
-variable "certificate_pem_secret_id" {
-  type        = string
-  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
-}
-
-variable "private_key_pem_secret_id" {
-  type        = string
-  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS private key."
-}

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -24,19 +24,19 @@ variable "key_name" {
   type        = string
 }
 
-variable "tfe_license_secret_name" {
+variable "tfe_license_secret_id" {
   type        = string
   description = <<-EOD
-  The name of the Secrets Manager secret under which the Base64 encoded Terraform Enterprise license is stored.
+  The name of the Secrets Manager secret ID of the Base64 encoded Terraform Enterprise license.
   EOD
 }
 
-variable "certificate_pem_secret_name" {
+variable "certificate_pem_secret_id" {
   type        = string
-  description = "The secrets manager secret name of the Base64 & PEM encoded TLS certificate."
+  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
 }
 
-variable "private_key_pem_secret_name" {
+variable "private_key_pem_secret_id" {
   type        = string
-  description = "The secrets manager secret name under which the Base64 & PEM encoded TLS private key."
+  description = "The secrets manager secret ID of the Base64 & PEM encoded TLS private key."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,6 @@ variable "distribution" {
   }
 }
 
-# TODO: Get this value from the acm_certificate_arn
 variable "vm_certificate_secret_id" {
   default     = null
   type        = string
@@ -30,7 +29,6 @@ variable "vm_certificate_secret_id" {
   EOD
 }
 
-# TODO: Get this value from the acm_certificate_arn
 variable "vm_key_secret_id" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

This branch adds the newly created TLS certificates to the appropriate tests. The cert/pem used here is the same that is used for `acm_certificate_arn` except in PEM format.

Asana: https://app.asana.com/0/0/1202037504110364/f
Relates: 

- #230
- #231 
- #232 
- https://github.com/hashicorp/ptfedev-infra/pull/394
- https://github.com/hashicorp/ptfedev-infra/pull/395
- https://github.com/hashicorp/ptfedev-infra/pull/396
- [UPDATED] https://github.com/hashicorp/ptfedev-infra/pull/397

## How Has This Been Tested

- [ ] `/test all` passes here

## This PR makes me feel

![please work](https://media.giphy.com/media/26FeSxFIfPgLHlTmE/giphy.gif)
