### PR TITLE
Ah license

### DIFF
--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -5,8 +5,12 @@ resource "random_string" "friendly_name" {
   special = false
 }
 
+# Store TFE License as secret
+# ---------------------------
 module "secrets" {
+  count  = var.license_file == null ? 0 : 1
   source = "../../fixtures/secrets"
+
   tfe_license = {
     name = "${local.friendly_name_prefix}-tfe-license"
     path = var.license_file
@@ -58,7 +62,7 @@ module "tfe" {
   acm_certificate_arn   = var.acm_certificate_arn
   domain_name           = "tfe-team-dev.aws.ptfedev.com"
   friendly_name_prefix  = local.friendly_name_prefix
-  tfe_license_secret_id = module.secrets.tfe_license_secret_id
+  tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                   = data.aws_ami.rhel.id
   distribution             = "rhel"

--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -19,6 +19,7 @@ variable "acm_certificate_arn" {
 }
 
 variable "license_file" {
+  default     = null
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }

--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -30,6 +30,7 @@ variable "object_storage_iam_user_name" {
 }
 
 variable "tfe_license_secret_id" {
+  default     = null
   type        = string
   description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
 }

--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -28,3 +28,8 @@ variable "object_storage_iam_user_name" {
   type        = string
   description = "The name of the IAM user which will be authorized to access the S3 storage bucket."
 }
+
+variable "tfe_license_secret_id" {
+  type        = string
+  description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
+}

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -9,9 +9,10 @@ resource "random_string" "friendly_name" {
 
 # Store TFE License as secret
 # ---------------------------
-
 module "secrets" {
+  count  = var.license_file == null ? 0 : 1
   source = "../../fixtures/secrets"
+
   tfe_license = {
     name = "${local.friendly_name_prefix}-tfe-license"
     path = var.license_file
@@ -43,7 +44,7 @@ module "standalone_vault" {
   acm_certificate_arn   = var.acm_certificate_arn
   domain_name           = "tfe-team-dev.aws.ptfedev.com"
   friendly_name_prefix  = local.friendly_name_prefix
-  tfe_license_secret_id = module.secrets.tfe_license_secret_id
+  tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   distribution          = "ubuntu"
 
   iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -13,3 +13,8 @@ variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
+
+variable "tfe_license_secret_id" {
+  type        = string
+  description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
+}

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -15,6 +15,7 @@ variable "license_file" {
 }
 
 variable "tfe_license_secret_id" {
+  default     = null
   type        = string
   description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
 }

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -9,6 +9,7 @@ variable "acm_certificate_arn" {
 }
 
 variable "license_file" {
+  default     = null
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,6 +180,18 @@ variable "disk_path" {
   type        = string
 }
 
+variable "iact_subnet_list" {
+  default     = []
+  description = "A list of CIDR masks that configure the ability to retrieve the IACT from outside the host."
+  type        = list(string)
+}
+
+variable "iact_subnet_time_limit" {
+  default     = 60
+  description = "The time limit that requests from the subnets listed can request the IACT, as measured from the instance creation in minutes."
+  type        = number
+}
+
 variable "operational_mode" {
   default     = "external"
   description = <<-EOD
@@ -297,12 +309,6 @@ variable "network_public_subnets" {
 
 # TFE Instance(s)
 # ---------------
-variable "iact_subnet_time_limit" {
-  default     = 60
-  description = "The time limit that requests from the subnets listed can request the IACT, as measured from the instance creation in minutes."
-  type        = number
-}
-
 variable "iam_role_policy_arns" {
   default     = []
   description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."

--- a/variables.tf
+++ b/variables.tf
@@ -206,12 +206,6 @@ variable "operational_mode" {
   }
 }
 
-variable "settings_module_source" {
-  type        = string
-  default     = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
-  description = "The value of the source argument for the settings module block."
-}
-
 variable "tbw_image" {
   default     = null
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,41 +1,14 @@
 # Common
 # ------
-variable "ami_id" {
-  type        = string
-  default     = null
-  description = "AMI ID to use for TFE instances"
-}
-
 variable "acm_certificate_arn" {
   type        = string
   description = "ACM certificate ARN to use with load balancer"
 }
 
-variable "distribution" {
+variable "ami_id" {
   type        = string
-  description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
-  validation {
-    condition     = contains(["rhel", "ubuntu"], var.distribution)
-    error_message = "Supported values for distribution are 'rhel' or 'ubuntu'."
-  }
-}
-
-variable "vm_certificate_secret_id" {
   default     = null
-  type        = string
-  description = <<-EOD
-  A Secrets Manager secret ARN which contains the Base64 encoded version of a PEM encoded public certificate for the Virtual
-  Machine Scale Set.
-  EOD
-}
-
-variable "vm_key_secret_id" {
-  default     = null
-  type        = string
-  description = <<-EOD
-  A Secrets Manager secret ARN which contains the Base64 encoded version of a PEM encoded private key for the Virtual Machine
-  Scale Set.
-  EOD
+  description = "AMI ID to use for TFE instances"
 }
 
 variable "asg_tags" {
@@ -66,56 +39,13 @@ variable "aws_secret_access_key" {
   type        = string
 }
 
-variable "object_storage_iam_user" {
-  default     = null
-  description = <<-EOD
-  The IAM user that will be authorized to access the S3 storage bucket which holds Terraform Enterprise runtime data.
-  This value requires var.aws_access_key_id and var.aws_secret_access_key to also be set. The values of those variables
-  must represent an access key that is associated with this user.
-  EOD
-  type        = object({ arn = string })
-}
-
-variable "redis_cache_size" {
+variable "distribution" {
   type        = string
-  default     = "cache.m4.large"
-  description = "Redis instance size."
-}
-
-variable "redis_engine_version" {
-  type        = string
-  default     = "5.0.6"
-  description = "Redis enginer version."
-}
-
-variable "redis_parameter_group_name" {
-  type        = string
-  default     = "default.redis5.0"
-  description = "Redis parameter group name."
-}
-
-variable "db_size" {
-  type        = string
-  default     = "db.m4.xlarge"
-  description = "PostgreSQL instance size."
-}
-
-variable "db_backup_retention" {
-  type        = number
-  description = "The days to retain backups for. Must be between 0 and 35"
-  default     = 0
-}
-
-variable "db_backup_window" {
-  type        = string
-  description = "The daily time range (in UTC) during which automated backups are created if they are enabled"
-  default     = null
-}
-
-variable "postgres_engine_version" {
-  type        = string
-  default     = "12.8"
-  description = "PostgreSQL version."
+  description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
+  validation {
+    condition     = contains(["rhel", "ubuntu"], var.distribution)
+    error_message = "Supported values for distribution are 'rhel' or 'ubuntu'."
+  }
 }
 
 variable "domain_name" {
@@ -132,6 +62,98 @@ variable "instance_type" {
   default     = "m5.xlarge"
   description = "The instance type of EC2 instance(s) to create."
   type        = string
+}
+
+variable "object_storage_iam_user" {
+  default     = null
+  description = <<-EOD
+  The IAM user that will be authorized to access the S3 storage bucket which holds Terraform Enterprise runtime data.
+  This value requires var.aws_access_key_id and var.aws_secret_access_key to also be set. The values of those variables
+  must represent an access key that is associated with this user.
+  EOD
+  type        = object({ arn = string })
+}
+
+variable "vm_certificate_secret_id" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  A Secrets Manager secret ARN which contains the Base64 encoded version of a PEM encoded public certificate for the Virtual
+  Machine Scale Set.
+  EOD
+}
+
+variable "vm_key_secret_id" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  A Secrets Manager secret ARN which contains the Base64 encoded version of a PEM encoded private key for the Virtual Machine
+  Scale Set.
+  EOD
+}
+
+# Redis
+# -----
+variable "redis_cache_size" {
+  type        = string
+  default     = "cache.m4.large"
+  description = "Redis instance size."
+}
+
+variable "redis_encryption_in_transit" {
+  type        = bool
+  description = "Determine whether Redis traffic is encrypted in transit."
+  default     = false
+}
+
+variable "redis_encryption_at_rest" {
+  type        = bool
+  description = "Determine whether Redis data is encrypted at rest."
+  default     = false
+}
+
+variable "redis_engine_version" {
+  type        = string
+  default     = "5.0.6"
+  description = "Redis enginer version."
+}
+
+variable "redis_parameter_group_name" {
+  type        = string
+  default     = "default.redis5.0"
+  description = "Redis parameter group name."
+}
+
+variable "redis_use_password_auth" {
+  type        = bool
+  description = "Determine if a password is required for Redis."
+  default     = false
+}
+
+# Postgres
+# --------
+variable "db_backup_retention" {
+  type        = number
+  description = "The days to retain backups for. Must be between 0 and 35"
+  default     = 0
+}
+
+variable "db_backup_window" {
+  type        = string
+  description = "The daily time range (in UTC) during which automated backups are created if they are enabled"
+  default     = null
+}
+
+variable "db_size" {
+  type        = string
+  default     = "db.m4.xlarge"
+  description = "PostgreSQL instance size."
+}
+
+variable "postgres_engine_version" {
+  type        = string
+  default     = "12.8"
+  description = "PostgreSQL version."
 }
 
 # Userdata
@@ -172,6 +194,12 @@ variable "operational_mode" {
   }
 }
 
+variable "settings_module_source" {
+  type        = string
+  default     = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
+  description = "The value of the source argument for the settings module block."
+}
+
 variable "tbw_image" {
   default     = null
   type        = string
@@ -189,6 +217,12 @@ variable "tbw_image" {
     )
     error_message = "The tbw_image must be 'default_image', 'custom_image', or null. If left unset, TFE will default to 'default_image'."
   }
+}
+
+variable "tfe_init_module_source" {
+  type        = string
+  default     = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  description = "The value of the source argument for the tfe_init module block."
 }
 
 variable "tfe_license_file_location" {
@@ -209,17 +243,185 @@ variable "tls_bootstrap_key_pathname" {
   description = "The path on the TFE instance to put the key. ex. '/var/lib/terraform-enterprise/key.pem'"
 }
 
-# Air-gapped Installations ONLY
-# -----------------------------
-variable "tfe_license_bootstrap_airgap_package_path" {
+# Network
+# -------
+variable "admin_dashboard_ingress_ranges" {
+  type        = list(string)
+  description = "(Optional) List of CIDR ranges that are allowed to acces the admin dashboard. Only used for standalone installations."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "deploy_vpc" {
+  type        = bool
+  description = "(Optional) Boolean indicating whether to deploy a VPC (true) or not (false)."
+  default     = true
+}
+
+variable "network_cidr" {
+  type        = string
+  description = "(Optional) CIDR block for VPC."
+  default     = "10.0.0.0/16"
+}
+
+variable "network_id" {
+  default     = null
+  description = "The identity of the VPC in which resources will be deployed."
+  type        = string
+}
+
+variable "network_private_subnet_cidrs" {
+  type        = list(string)
+  description = "(Optional) List of private subnet CIDR ranges to create in VPC."
+  default     = ["10.0.32.0/20", "10.0.48.0/20"]
+}
+
+variable "network_private_subnets" {
+  default     = []
+  description = "A list of the identities of the private subnetworks in which resources will be deployed."
+  type        = list(string)
+}
+
+
+variable "network_public_subnet_cidrs" {
+  type        = list(string)
+  description = "(Optional) List of public subnet CIDR ranges to create in VPC."
+  default     = ["10.0.0.0/20", "10.0.16.0/20"]
+}
+
+
+variable "network_public_subnets" {
+  default     = []
+  description = "A list of the identities of the public subnetworks in which resources will be deployed."
+  type        = list(string)
+}
+
+# TFE Instance(s)
+# ---------------
+variable "iact_subnet_time_limit" {
+  default     = 60
+  description = "The time limit that requests from the subnets listed can request the IACT, as measured from the instance creation in minutes."
+  type        = number
+}
+
+variable "iam_role_policy_arns" {
+  default     = []
+  description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."
+  type        = set(string)
+}
+
+variable "key_name" {
+  default     = null
+  description = "The name of the key pair to be used for SSH access to the EC2 instance(s)."
+  type        = string
+}
+
+variable "node_count" {
+  type        = number
+  default     = 2
+  description = "The number of nodes you want in your autoscaling group (1 for standalone, 2 for active-active configuration)"
+
+  validation {
+    condition     = var.node_count <= 5
+    error_message = "The node_count value must be less than or equal to 5."
+  }
+}
+
+variable "pg_extra_params" {
+  default     = null
+  type        = string
+  description = <<-EOF
+  Parameter keywords of the form param1=value1&param2=value2 to support additional options that
+  may be necessary for your specific PostgreSQL server. Allowed values are documented on the
+  PostgreSQL site. An additional restriction on the sslmode parameter is that only the require,
+  verify-full, verify-ca, and disable values are allowed.
+  EOF
+}
+
+variable "release_sequence" {
+  default     = null
+  type        = number
+  description = "Terraform Enterprise release sequence"
+}
+
+variable "ssl_policy" {
+  type        = string
+  default     = "ELBSecurityPolicy-2016-08"
+  description = "SSL policy to use on ALB listener"
+}
+
+variable "tfe_subdomain" {
+  type        = string
+  default     = "tfe"
+  description = "Subdomain for accessing the Terraform Enterprise UI."
+}
+
+# KMS & Secrets Manager
+# ---------------------
+variable "ca_certificate_secret_id" {
   default     = null
   type        = string
   description = <<-EOD
-  (Required if air-gapped installation) The URL of a Replicated airgap package for Terraform
-  Enterprise. The suggested path is "/var/lib/ptfe/ptfe.airgap".
+  A Secrets Manager secret ARN to the secret which contains the Base64 encoded version of
+  a PEM encoded public certificate of a certificate authority (CA) to be trusted by the EC2
+  instance(s). This argument is only required if TLS certificates in the deployment are not
+  issued by a well-known CA.
   EOD
 }
 
+variable "kms_key_arn" {
+  type        = string
+  description = "KMS key arn for AWS KMS Customer managed key."
+}
+
+variable "tfe_license_secret_id" {
+  type        = string
+  description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
+}
+
+# Load Balancer
+# -------------
+variable "load_balancing_scheme" {
+  default     = "PRIVATE"
+  description = "Load Balancing Scheme. Supported values are: \"PRIVATE\"; \"PRIVATE_TCP\"; \"PUBLIC\"."
+  type        = string
+
+  validation {
+    condition     = contains(["PRIVATE", "PRIVATE_TCP", "PUBLIC"], var.load_balancing_scheme)
+    error_message = "The load_balancer value must be one of: \"PRIVATE\"; \"PRIVATE_TCP\"; \"PUBLIC\"."
+  }
+}
+
+# Proxy Settings
+# --------------
+variable "no_proxy" {
+  type        = list(string)
+  description = "(Optional) List of IP addresses to not proxy"
+  default     = []
+}
+
+variable "proxy_ip" {
+  type        = string
+  description = "(Optional) IP address of existing web proxy to route TFE traffic through."
+  default     = null
+}
+
+variable "proxy_port" {
+  default     = null
+  type        = string
+  description = "Port that the proxy server will use"
+}
+
+variable "trusted_proxies" {
+  default     = []
+  description = <<-EOD
+  A list of IP address ranges which will be considered safe to ignore when evaluating the IP addresses of requests like
+  those made to the IACT endpoint.
+  EOD
+  type        = list(string)
+}
+
+# Air-gapped Installations ONLY
+# -----------------------------
 variable "airgap_url" {
   default     = null
   type        = string
@@ -230,12 +432,33 @@ variable "airgap_url" {
   EOD
 }
 
+variable "tfe_license_bootstrap_airgap_package_path" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  (Required if air-gapped installation) The URL of a Replicated airgap package for Terraform
+  Enterprise. The suggested path is "/var/lib/ptfe/ptfe.airgap".
+  EOD
+}
+
 # Mounted Disk Installations ONLY
 # -------------------------------
+variable "ebs_delete_on_termination" {
+  type        = bool
+  default     = true
+  description = "(Optional if Mounted Disk installation) Whether the volume should be destroyed on instance termination."
+}
+
 variable "ebs_device_name" {
   type        = string
   default     = "xvdcc"
   description = "(Required if Mounted Disk installation) The name of the device to mount."
+}
+
+variable "ebs_iops" {
+  type        = number
+  default     = 3000
+  description = "(Optional if Mounted Disk installation) The amount of provisioned IOPS. This must be set with a volume_type of 'io1'."
 }
 
 variable "ebs_renamed_device_name" {
@@ -264,234 +487,30 @@ variable "ebs_volume_type" {
   }
 }
 
-variable "ebs_iops" {
-  type        = number
-  default     = 3000
-  description = "(Optional if Mounted Disk installation) The amount of provisioned IOPS. This must be set with a volume_type of 'io1'."
-}
-
-variable "ebs_delete_on_termination" {
-  type        = bool
-  default     = true
-  description = "(Optional if Mounted Disk installation) Whether the volume should be destroyed on instance termination."
-}
-
-# Network
-# -------
-variable "network_id" {
-  default     = null
-  description = "The identity of the VPC in which resources will be deployed."
-  type        = string
-}
-
-variable "network_private_subnets" {
-  default     = []
-  description = "A list of the identities of the private subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "network_public_subnets" {
-  default     = []
-  description = "A list of the identities of the public subnetworks in which resources will be deployed."
-  type        = list(string)
-}
-
-variable "deploy_vpc" {
-  type        = bool
-  description = "(Optional) Boolean indicating whether to deploy a VPC (true) or not (false)."
-  default     = true
-}
-
-variable "network_cidr" {
-  type        = string
-  description = "(Optional) CIDR block for VPC."
-  default     = "10.0.0.0/16"
-}
-
-variable "network_private_subnet_cidrs" {
-  type        = list(string)
-  description = "(Optional) List of private subnet CIDR ranges to create in VPC."
-  default     = ["10.0.32.0/20", "10.0.48.0/20"]
-}
-
-variable "network_public_subnet_cidrs" {
-  type        = list(string)
-  description = "(Optional) List of public subnet CIDR ranges to create in VPC."
-  default     = ["10.0.0.0/20", "10.0.16.0/20"]
-}
-
-variable "admin_dashboard_ingress_ranges" {
-  type        = list(string)
-  description = "(Optional) List of CIDR ranges that are allowed to acces the admin dashboard. Only used for standalone installations."
-  default     = ["0.0.0.0/0"]
-}
-
-# TFE Instance(s)
-# ---------------
-variable "node_count" {
-  type        = number
-  default     = 2
-  description = "The number of nodes you want in your autoscaling group (1 for standalone, 2 for active-active configuration)"
-
-  validation {
-    condition     = var.node_count <= 5
-    error_message = "The node_count value must be less than or equal to 5."
-  }
-}
-
-variable "ssl_policy" {
-  type        = string
-  default     = "ELBSecurityPolicy-2016-08"
-  description = "SSL policy to use on ALB listener"
-}
-
-variable "tfe_subdomain" {
-  type        = string
-  default     = "tfe"
-  description = "Subdomain for accessing the Terraform Enterprise UI."
-}
-
-variable "iact_subnet_list" {
-  default     = []
-  description = "A list of CIDR masks that configure the ability to retrieve the IACT from outside the host."
-  type        = list(string)
-}
-
-variable "iact_subnet_time_limit" {
-  default     = 60
-  description = "The time limit that requests from the subnets listed can request the IACT, as measured from the instance creation in minutes."
-  type        = number
-}
-
-variable "iam_role_policy_arns" {
-  default     = []
-  description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."
-  type        = set(string)
-}
-
-variable "key_name" {
-  default     = null
-  description = "The name of the key pair to be used for SSH access to the EC2 instance(s)."
-  type        = string
-}
-
-variable "release_sequence" {
-  default     = null
-  type        = number
-  description = "Terraform Enterprise release sequence"
-}
-
-variable "pg_extra_params" {
+# External Vault ONLY
+# -------------------
+variable "extern_vault_addr" {
   default     = null
   type        = string
-  description = <<-EOF
-  Parameter keywords of the form param1=value1&param2=value2 to support additional options that
-  may be necessary for your specific PostgreSQL server. Allowed values are documented on the
-  PostgreSQL site. An additional restriction on the sslmode parameter is that only the require,
-  verify-full, verify-ca, and disable values are allowed.
-  EOF
+  description = "(Required if var.extern_vault_enable = true) URL of external Vault cluster."
 }
 
-# KMS
-# ---
-variable "kms_key_arn" {
-  type        = string
-  description = "KMS key arn for AWS KMS Customer managed key."
-}
-
-# Secrets Manager
-# ---------------
-
-variable "tfe_license_secret_id" {
-  type        = string
-  description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
-}
-
-variable "ca_certificate_secret_id" {
-  default     = null
-  type        = string
-  description = <<-EOD
-  A Secrets Manager secret ARN to the secret which contains the Base64 encoded version of
-  a PEM encoded public certificate of a certificate authority (CA) to be trusted by the EC2
-  instance(s). This argument is only required if TLS certificates in the deployment are not
-  issued by a well-known CA.
-  EOD
-}
-
-# Load Balancer
-# -------------
-variable "load_balancing_scheme" {
-  default     = "PRIVATE"
-  description = "Load Balancing Scheme. Supported values are: \"PRIVATE\"; \"PRIVATE_TCP\"; \"PUBLIC\"."
-  type        = string
-
-  validation {
-    condition     = contains(["PRIVATE", "PRIVATE_TCP", "PUBLIC"], var.load_balancing_scheme)
-    error_message = "The load_balancer value must be one of: \"PRIVATE\"; \"PRIVATE_TCP\"; \"PUBLIC\"."
-  }
-}
-
-# PROXY SETTINGS
-# --------------
-variable "proxy_ip" {
-  type        = string
-  description = "(Optional) IP address of existing web proxy to route TFE traffic through."
-  default     = null
-}
-
-variable "proxy_port" {
-  default     = null
-  type        = string
-  description = "Port that the proxy server will use"
-}
-
-variable "no_proxy" {
-  type        = list(string)
-  description = "(Optional) List of IP addresses to not proxy"
-  default     = []
-}
-
-variable "trusted_proxies" {
-  default     = []
-  description = <<-EOD
-  A list of IP address ranges which will be considered safe to ignore when evaluating the IP addresses of requests like
-  those made to the IACT endpoint.
-  EOD
-  type        = list(string)
-}
-
-# Redis
-# -----
-variable "redis_encryption_in_transit" {
-  type        = bool
-  description = "Determine whether Redis traffic is encrypted in transit."
-  default     = false
-}
-
-variable "redis_encryption_at_rest" {
-  type        = bool
-  description = "Determine whether Redis data is encrypted at rest."
-  default     = false
-}
-
-variable "redis_use_password_auth" {
-  type        = bool
-  description = "Determine if a password is required for Redis."
-  default     = false
-}
-
-# External Vault
-# --------------
 variable "extern_vault_enable" {
   default     = false
   type        = bool
   description = "(Optional) Indicate if an external Vault cluster is being used. Set to 1 if so."
 }
 
-variable "extern_vault_addr" {
+variable "extern_vault_namespace" {
   default     = null
   type        = string
-  description = "(Required if var.extern_vault_enable = true) URL of external Vault cluster."
+  description = "(Optional if var.extern_vault_enable = true) The Vault namespace"
+}
+
+variable "extern_vault_path" {
+  default     = "auth/approle"
+  type        = string
+  description = "(Optional if var.extern_vault_enable = true) Path on the Vault server for the AppRole auth. Defaults to auth/approle."
 }
 
 variable "extern_vault_role_id" {
@@ -506,21 +525,9 @@ variable "extern_vault_secret_id" {
   description = "(Required if var.extern_vault_enable = true) AppRole SecretId to use to authenticate with the Vault cluster."
 }
 
-variable "extern_vault_path" {
-  default     = "auth/approle"
-  type        = string
-  description = "(Optional if var.extern_vault_enable = true) Path on the Vault server for the AppRole auth. Defaults to auth/approle."
-}
 
 variable "extern_vault_token_renew" {
   default     = 3600
   type        = number
   description = "(Optional if var.extern_vault_enable = true) How often (in seconds) to renew the Vault token."
 }
-
-variable "extern_vault_namespace" {
-  default     = null
-  type        = string
-  description = "(Optional if var.extern_vault_enable = true) The Vault namespace"
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -231,12 +231,6 @@ variable "tbw_image" {
   }
 }
 
-variable "tfe_init_module_source" {
-  type        = string
-  default     = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
-  description = "The value of the source argument for the tfe_init module block."
-}
-
 variable "tfe_license_file_location" {
   default     = "/etc/terraform-enterprise.rli"
   type        = string


### PR DESCRIPTION
## Background

This is the first in a series of changes that will allow for these tests to be extensible enough for the Utility repo to use them for its CI testing.

(The large changes in the root `variables.tf` is just alphabetizing the vars by section.)

Asana: 
* https://app.asana.com/0/0/1202263752328887/f
* https://app.asana.com/0/0/1202263750875048/f

## How Has This Been Tested

I successfully tested this in ptfe-replicated [here](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated?branch=ah-license&filter=all).

## This PR makes me feel

![let's do it](https://media.giphy.com/media/y9XCVEKx02Q3tyHSD5/giphy.gif)
