### PR TITLE
remove region to use env var in CI

### DIFF
--- a/tests/standalone-vault/locals.tf
+++ b/tests/standalone-vault/locals.tf
@@ -1,14 +1,13 @@
 locals {
   common_tags = {
     Terraform   = "False"
-    Environment = "ptfe-replicated CI"
+    Environment = var.license_file == null ? "tfe_utilities_test" : "ptfe-replicated CI"
     Description = "Standalone Vault"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"
   }
 
-  region                = "us-west-2"
   friendly_name_prefix  = random_string.friendly_name.id
   test_name             = "${local.friendly_name_prefix}-test-standalone-vault"
   load_balancing_scheme = "PUBLIC"

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -42,7 +42,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn   = var.acm_certificate_arn
-  domain_name           = "tfe-team-dev.aws.ptfedev.com"
+  domain_name           = var.domain_name
   friendly_name_prefix  = local.friendly_name_prefix
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   distribution          = "ubuntu"

--- a/tests/standalone-vault/provider.tf
+++ b/tests/standalone-vault/provider.tf
@@ -1,6 +1,4 @@
 provider "aws" {
-  region = local.region
-
   assume_role {
     role_arn = var.aws_role_arn
   }

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -8,6 +8,11 @@ variable "acm_certificate_arn" {
   description = "The ARN of an existing ACM certificate."
 }
 
+variable "domain_name" {
+  type        = string
+  description = "Domain for creating the Terraform Enterprise subdomain on."
+}
+
 variable "license_file" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263752337764/f
In order for this test to be able to be used by both the Utilities modules testing as well as `ptfe-replicated` CI, this branch:
* allows for ptfe-replicated CI to use the `AWS_DEFAULT_REGION` environment variable that is already currently be supplied to the pipeline
* changes the `Environment` tag based on which test is being run
* add variable for `domain_name`

This branch will need to be merged first, and then the `ptfe-replicated` branch may merge.

## How Has This Been Tested

[This branch was targeted for this run in ptfe-replicated CI.](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/3894/workflows/09ff7605-7ede-4559-9d49-bd63b5088b72/jobs/23280)

## This PR makes me feel

![baby steps](https://media.giphy.com/media/j6psonSbB0eOPfLtc8/giphy.gif)
