### PR TITLE
add key name var

### DIFF
--- a/tests/standalone-vault/README.md
+++ b/tests/standalone-vault/README.md
@@ -28,7 +28,9 @@ This test assumes the following resources exist.
 
 ## How this test is used
 
-This test is leveraged by the integration tests in the [`ptfe-replicated`](https://github.com/hashicorp/ptfe-replicated/blob/master/.circleci/config.yml)
+This test is used in two different CI pipelines.
+
+1. This test is leveraged by the integration tests in the [`ptfe-replicated`](https://github.com/hashicorp/ptfe-replicated/blob/master/.circleci/config.yml)
 repository.
 
 Because the Vault provider is dependent upon output from the HCP resources, we must
@@ -39,3 +41,5 @@ $ terraform apply -target=module.hcp_vault.hcp_vault_cluster.test -target=module
 
 $ terraform apply
 ```
+
+2. This test is used to test changes made to the fixture and utility modules in the [terraform-random-tfe-utility](https://github.com/hashicorp/terraform-random-tfe-utility) repository.

--- a/tests/standalone-vault/locals.tf
+++ b/tests/standalone-vault/locals.tf
@@ -11,4 +11,5 @@ locals {
   friendly_name_prefix  = random_string.friendly_name.id
   test_name             = "${local.friendly_name_prefix}-test-standalone-vault"
   load_balancing_scheme = "PUBLIC"
+  utility_module_test   = var.license_file == null
 }

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -10,7 +10,7 @@ resource "random_string" "friendly_name" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = var.license_file == null ? 0 : 1
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {
@@ -50,7 +50,7 @@ module "standalone_vault" {
   iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list            = ["0.0.0.0/0"]
   instance_type               = "m5.xlarge"
-  key_name                    = "standalone-vault"
+  key_name                    = local.utility_module_test ? var.key_name : "standalone-vault"
   kms_key_arn                 = module.kms.key
   load_balancing_scheme       = local.load_balancing_scheme
   node_count                  = 1

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -13,6 +13,12 @@ variable "domain_name" {
   description = "Domain for creating the Terraform Enterprise subdomain on."
 }
 
+variable "key_name" {
+  default     = null
+  description = "The name of the key pair to be used for SSH access to the EC2 instance(s)."
+  type        = string
+}
+
 variable "license_file" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263752337764/f

This branch adds a local value for `utility_module_test` for simplicity. It also adds the `key_name` variable that the TFC workspace would need.

## How Has This Been Tested

- [x] [ptfe-replicated `aws_standalone_vault` test passes](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/3928/workflows/caf83619-c6fb-4906-9720-9d83f5f4bf9c/jobs/23393)

## This PR makes me feel

![reuse](https://media.giphy.com/media/3Lxbvq9HNOVM8TfyOu/giphy.gif)
