### PR TITLE
add vars for utility tests

### DIFF
--- a/tests/active-active-rhel7-proxy/data.tf
+++ b/tests/active-active-rhel7-proxy/data.tf
@@ -1,9 +1,9 @@
 data "aws_secretsmanager_secret" "ca_certificate" {
-  name = "terraform-20211022160427310700000001"
+  name = var.ca_certificate_secret_name
 }
 
 data "aws_secretsmanager_secret" "ca_private_key" {
-  name = "terraform-20211022160427312200000003"
+  name = var.ca_private_key_secret_name
 }
 
 data "aws_ami" "rhel" {

--- a/tests/active-active-rhel7-proxy/locals.tf
+++ b/tests/active-active-rhel7-proxy/locals.tf
@@ -2,7 +2,7 @@ locals {
 
   common_tags = {
     Terraform   = "cloud"
-    Environment = "tfe_team_dev"
+    Environment = local.utility_module_test ? "tfe_modules_test" : "tfe_team_dev"
     Description = "Active/Active on RHEL with Proxy scenario deployed from CircleCI"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
@@ -16,4 +16,5 @@ locals {
   iam_principal         = data.aws_iam_user.ci_s3.arn
   load_balancing_scheme = "PUBLIC"
   http_proxy_port       = "3128"
+  utility_module_test   = var.license_file == null
 }

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -8,7 +8,7 @@ resource "random_string" "friendly_name" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = var.license_file == null ? 0 : 1
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {
@@ -18,7 +18,7 @@ module "secrets" {
 }
 
 data "aws_iam_user" "ci_s3" {
-  user_name = "TFE-S3"
+  user_name = var.object_storage_iam_user_name
 }
 
 module "kms" {
@@ -60,7 +60,7 @@ module "tfe" {
   source = "../../"
 
   acm_certificate_arn   = var.acm_certificate_arn
-  domain_name           = "tfe-team-dev.aws.ptfedev.com"
+  domain_name           = var.domain_name
   friendly_name_prefix  = local.friendly_name_prefix
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 

--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -18,6 +18,21 @@ variable "acm_certificate_arn" {
   description = "The ARN of an existing ACM certificate."
 }
 
+variable "ca_certificate_secret_name" {
+  type        = string
+  description = "The secrets manager secret name of the Base64 encoded CA certificate."
+}
+
+variable "ca_private_key_secret_name" {
+  type        = string
+  description = "The secrets manager secret name of the Base64 encoded CA private key."
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain for creating the Terraform Enterprise subdomain on."
+}
+
 variable "license_file" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/0/1202263750888055/f
This [test run](https://github.com/hashicorp/terraform-random-tfe-utility/pull/33) showed me that there were a lot of hard-coded values that were specific to the AWS account that the `ptfe-replicated` tests were running in, so I had to make them variables, add the variables to both the `ptfe-replicated` script as well as the TFC workspace that this will run in, and test again. 

After this merges, this [pull request](https://github.com/hashicorp/ptfe-replicated/pull/1086) of `ptfe-replicated` will need to be merged. 

## How Has This Been Tested

[This branch](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/3945/workflows/fb1efcdc-1921-4819-9312-f75ad0ff6989/jobs/23442) of `ptfe-replicated` tests these changes. 

- [x]  Passing Test

## This PR makes me feel

![what else did I miss](https://media.giphy.com/media/Y4iNEtsEseq6gEPp9e/giphy.gif)
