### PR TITLE
Jkerry/upgrade hcp provider

### DIFF
--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -25,7 +25,7 @@ module "kms" {
 }
 
 module "hcp_vault" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//fixtures/test_hcp_vault?ref=jkerry/upgrade-hcp-provider"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//fixtures/test_hcp_vault?ref=main"
 
   hcp_vault_cluster_id              = local.test_name
   hcp_vault_cluster_hvn_id          = "team-tfe-dev-hvn"

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -25,7 +25,7 @@ module "kms" {
 }
 
 module "hcp_vault" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//fixtures/test_hcp_vault?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//fixtures/test_hcp_vault?ref=jkerry/upgrade-hcp-provider"
 
   hcp_vault_cluster_id              = local.test_name
   hcp_vault_cluster_hvn_id          = "team-tfe-dev-hvn"

--- a/tests/standalone-vault/versions.tf
+++ b/tests/standalone-vault/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     hcp = {
       source  = "hashicorp/hcp"
-      version = "0.18.0"
+      version = "~> 0.33.0"
     }
     vault = {
       source  = "hashicorp/vault"


### PR DESCRIPTION
## Background

This change pulls the hard version pin on the HCP provider to resolve some testing issues discovered in nightly builds

## How Has This Been Tested

Tests have been executed through the CircleCI tests on ptfe-replicated

## This PR makes me feel

<img src="https://media0.giphy.com/media/UZuAr03kNcTL71bTWj/giphy.gif"/>
