### PR TITLE
fixes "Warning: Argument is deprecated" for s3 related settings

### DIFF
--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tfe_data_bucket" 
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "tfe_data" {
+resource "aws_s3_bucket_public_access_block" "tfe_data_bucket" {
   bucket = aws_s3_bucket.tfe_data_bucket.id
 
   block_public_acls       = true

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -69,6 +69,6 @@ data "aws_iam_policy_document" "tfe_data_bucket" {
 resource "aws_s3_bucket_policy" "tfe_data_bucket" {
   # Depending on aws_s3_bucket_public_access_block.tfe_data avoids an error due to conflicting, simultaneous operations
   # against the bucket.
-  bucket = aws_s3_bucket_public_access_block.tfe_data.bucket
-  policy = data.aws_iam_policy_document.tfe_data.json
+  bucket = aws_s3_bucket_public_access_block.tfe_data_bucket.bucket
+  policy = data.aws_iam_policy_document.tfe_data_bucket.json
 }

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "tfe_data_bucket" {
-  bucket = "${var.friendly_name_prefix}-tfe-data"
+  bucket        = "${var.friendly_name_prefix}-tfe-data"
   force_destroy = true
 }
 


### PR DESCRIPTION
## Background

Since aws provider version 4.0 these bucket settings have been moved to their own resources 

## How Has This Been Tested

deployed to my test environment, bucket settings remained the same, but now managed as separate resources alleviating the warning messages. 

### Test Configuration

* Terraform Core - 1.2.5
* AWS Provider - 4.22.0