### PR TITLE
Adding metrics variables and passing them through to the settings module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,15 +116,18 @@ module "settings" {
   source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
 
   # TFE Base Configuration
-  custom_image_tag       = var.custom_image_tag
-  production_type        = var.operational_mode
-  disk_path              = local.enable_disk ? var.disk_path : null
-  iact_subnet_list       = var.iact_subnet_list
-  iact_subnet_time_limit = var.iact_subnet_time_limit
-  trusted_proxies        = var.trusted_proxies
-  release_sequence       = var.release_sequence
-  pg_extra_params        = var.pg_extra_params
-  tbw_image              = var.tbw_image
+  custom_image_tag            = var.custom_image_tag
+  production_type             = var.operational_mode
+  disk_path                   = local.enable_disk ? var.disk_path : null
+  iact_subnet_list            = var.iact_subnet_list
+  iact_subnet_time_limit      = var.iact_subnet_time_limit
+  metrics_endpoint_enabled    = var.metrics_endpoint_enabled
+  metrics_endpoint_port_http  = var.metrics_endpoint_port_http
+  metrics_endpoint_port_https = var.metrics_endpoint_port_https
+  trusted_proxies             = var.trusted_proxies
+  release_sequence            = var.release_sequence
+  pg_extra_params             = var.pg_extra_params
+  tbw_image                   = var.tbw_image
 
   extra_no_proxy = concat([
     "127.0.0.1",

--- a/variables.tf
+++ b/variables.tf
@@ -192,6 +192,36 @@ variable "iact_subnet_time_limit" {
   type        = number
 }
 
+variable "metrics_endpoint_enabled" {
+  default     = null
+  type        = bool
+  description = <<-EOD
+  (Optional) Metrics are used to understand the behavior of Terraform Enterprise and to
+  troubleshoot and tune performance. Enable an endpoint to expose container metrics.
+  Defaults to false.
+  EOD
+}
+
+variable "metrics_endpoint_port_http" {
+  default     = null
+  type        = number
+  description = <<-EOD
+  (Optional when metrics_endpoint_enabled is true.) Defines the TCP port on which HTTP metrics
+  requests will be handled.
+  Defaults to 9090.
+  EOD
+}
+
+variable "metrics_endpoint_port_https" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  (Optional when metrics_endpoint_enabled is true.) Defines the TCP port on which HTTPS metrics
+  requests will be handled.
+  Defaults to 9091.
+  EOD
+}
+
 variable "operational_mode" {
   default     = "external"
   description = <<-EOD


### PR DESCRIPTION

## Background

This change enables TFE metrics and increases cloud parity across the 3 major cloud estates.

## How Has This Been Tested

This change will be tested with standard /test targets.

## This PR makes me feel

<img src="https://media1.giphy.com/media/3o6MbjnP31zfxSI2Zi/giphy.gif"/>
