### PR TITLE
Doormat action consumption test pt. 1

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -57,7 +57,17 @@ jobs:
           terraform_wrapper: true
 
       # Run Terraform commands between these comments vvv
-
+      - id: doormat-action
+        uses: hashicorp/doormat-action@v1
+        with:
+          aws-role-arn: arn:aws:iam::873298400219:role/gha_doormat_role
+      - name: Configure Provider
+        id: config
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          echo "aws_access_key_id=\"$AWS_ACCESS_KEY_ID\"" > ./terraform.auto.tfvars
+          echo "aws_secret_access_key=\"$AWS_SECRET_ACCESS_KEY\"" >> ./terraform.auto.tfvars
+          echo "aws_session_token=\"$AWS_SESSION_TOKEN\"" >> ./terraform.auto.tfvars
       - name: Terraform Init
         id: init
         working-directory: ${{ env.WORK_DIR_PATH }}

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
-  assume_role {
-    role_arn = var.aws_role_arn
-  }
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
+  token      = var.aws_session_token
 
   default_tags {
     tags = local.common_tags

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -1,3 +1,18 @@
+variable "aws_access_key_id" {
+  type        = string
+  description = "The identity of the access key which TFE will use to provision resources and authenticate with S3."
+}
+
+variable "aws_secret_access_key" {
+  type        = string
+  description = "The secret access key which TFE will use to provision resources and authenticate with S3."
+}
+
+variable "aws_session_token" {
+  type        = string
+  description = "The session token which TFE will used to provision resources."
+}
+
 variable "acm_certificate_arn" {
   type        = string
   description = "The ARN of an existing ACM certificate."

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -18,11 +18,6 @@ variable "acm_certificate_arn" {
   description = "The ARN of an existing ACM certificate."
 }
 
-variable "aws_role_arn" {
-  type        = string
-  description = "The AWS Role ARN to assume for this module."
-}
-
 variable "domain_name" {
   type        = string
   description = "Domain for creating the Terraform Enterprise subdomain on."


### PR DESCRIPTION
## Background

This change begins to address SECS-438 and SECS-439 by adding the doormat action to a single test.  I suspect that this change will not work as intended because the credentials assigned by doormat are likely to be host specific and won't survive the GHA to TFC boundary, but we need to get the actions changes into main to find out for sure.

## How Has This Been Tested

Some light local testing, with local credentials, have failed due to host specific credential assignment, but we'll have to see in live testing.  Standard validate/fmt/tflint has passed.

## This PR makes me feel

<img src="https://media1.giphy.com/media/feLeAxp6kh8nqr97jq/giphy.gif"/>

<img src="https://media2.giphy.com/media/Y2c0QZJwOxGiviZL53/giphy.gif"/>

<img src="https://media2.giphy.com/media/fHohZYqIlE6YtdL9mf/giphy.gif"/>
