### PR TITLE
Small change to the standalone mounted disk example - OS variable

### DIFF
--- a/examples/standalone-mounted/main.tf
+++ b/examples/standalone-mounted/main.tf
@@ -51,7 +51,7 @@ module "standalone" {
   operational_mode    = "disk"
   acm_certificate_arn = var.acm_certificate_arn
   domain_name         = var.domain_name
-  distribution        = "ubuntu"
+  distribution        = var.distribution
 
   asg_tags                    = var.tags
   disk_path                   = "/opt/hashicorp/data"

--- a/examples/standalone-mounted/terraform.tfvars.example
+++ b/examples/standalone-mounted/terraform.tfvars.example
@@ -1,6 +1,7 @@
 acm_certificate_arn  = "arn:aws:acm:region:<account_id>:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
 domain_name          = "my.domain.com"
 license_file         = "/files/license.rli"
+distribution         = "ubuntu"
 tags                 = {
                         Owner       = "My Name"
                         Environment = "standalone-mounted"

--- a/examples/standalone-mounted/variables.tf
+++ b/examples/standalone-mounted/variables.tf
@@ -27,3 +27,9 @@ variable "tfe_subdomain" {
   type        = string
   description = "Subdomain for TFE"
 }
+
+variable "distribution" {
+  type        = string
+  default     = "ubuntu"
+  description = "The OS distribution to use, either ubuntu or rhel."
+}


### PR DESCRIPTION
## Background

This updates the example for standalone mounted disk to accept either rhel or ubuntu for the os distribution. Default variable is set to ubuntu.


Relates OR Closes #0000


## How Has This Been Tested

testing in progress...

### Test Configuration

* Terraform Version:
* Any additional relevant variables:

## This PR makes me feel

![optional gif describing your feelings about this pr]()
