### PR TITLE
allow bringing an existing instance role & profile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,14 +29,16 @@ data "aws_kms_key" "main" {
 module "service_accounts" {
   source = "./modules/service_accounts"
 
-  ca_certificate_secret_id = var.ca_certificate_secret_id
-  friendly_name_prefix     = var.friendly_name_prefix
-  iam_role_policy_arns     = var.iam_role_policy_arns
-  enable_airgap            = local.enable_airgap
-  tfe_license_secret_id    = var.tfe_license_secret_id
-  kms_key_arn              = local.kms_key_arn
-  vm_certificate_secret_id = var.vm_certificate_secret_id
-  vm_key_secret_id         = var.vm_key_secret_id
+  ca_certificate_secret_id           = var.ca_certificate_secret_id
+  friendly_name_prefix               = var.friendly_name_prefix
+  existing_iam_instance_role_name    = var.existing_iam_instance_role_name
+  existing_iam_instance_profile_name = var.existing_iam_instance_profile_name
+  iam_role_policy_arns               = var.iam_role_policy_arns
+  enable_airgap                      = local.enable_airgap
+  tfe_license_secret_id              = var.tfe_license_secret_id
+  kms_key_arn                        = local.kms_key_arn
+  vm_certificate_secret_id           = var.vm_certificate_secret_id
+  vm_key_secret_id                   = var.vm_key_secret_id
 }
 
 # -----------------------------------------------------------------------------

--- a/modules/service_accounts/data.tf
+++ b/modules/service_accounts/data.tf
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-data "aws_iam_instance_profile" "tfe" {
+data "aws_iam_instance_profile" "existing_instance_profile" {
   count = var.existing_iam_instance_profile_name == null ? 0 : 1
   name  = var.existing_iam_instance_profile_name
 }
 
-data "aws_iam_role" "instance_role" {
+data "aws_iam_role" "existing_instance_role" {
   count = var.existing_iam_instance_role_name == null ? 0 : 1
   name  = var.existing_iam_instance_role_name
 }

--- a/modules/service_accounts/data.tf
+++ b/modules/service_accounts/data.tf
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "aws_iam_instance_profile" "tfe" {
+  count = var.existing_iam_instance_profile_name == null ? 0 : 1
+  name  = var.existing_iam_instance_profile_name
+}
+
+data "aws_iam_role" "instance_role" {
+  count = var.existing_iam_instance_role_name == null ? 0 : 1
+  name  = var.existing_iam_instance_role_name
+}

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -9,6 +9,6 @@ locals {
     var.vm_key_secret_id
   ] : secret if secret != null]
 
-  iam_instance_role    = try(data.aws_iam_role.instance_role[0], aws_iam_role.instance_role[0])
-  iam_instance_profile = try(data.aws_iam_instance_profile.tfe[0], aws_iam_instance_profile.tfe[0])
+  iam_instance_role    = try(data.aws_iam_role.existing_instance_role[0], aws_iam_role.instance_role[0])
+  iam_instance_profile = try(data.aws_iam_instance_profile.existing_instance_profile[0], aws_iam_instance_profile.tfe[0])
 }

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -8,4 +8,7 @@ locals {
     var.vm_certificate_secret_id,
     var.vm_key_secret_id
   ] : secret if secret != null]
+
+  iam_instance_role    = try(data.aws_iam_role.instance_role[0], aws_iam_role.instance_role[0])
+  iam_instance_profile = try(data.aws_iam_instance_profile.tfe[0], aws_iam_instance_profile.tfe[0])
 }

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "iam_instance_profile" {
-  value = aws_iam_instance_profile.tfe
+  value = local.iam_instance_profile
 
   description = "The IAM instance profile to be attached to the TFE EC2 instance(s)."
 }
 
 output "iam_role" {
-  value = aws_iam_role.instance_role
+  value = local.iam_instance_role
 
   description = "The IAM role associated with the instance profile."
 }

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -9,6 +9,16 @@ variable "ca_certificate_secret_id" {
   EOD
 }
 
+variable "existing_iam_instance_profile_name" {
+  description = "The IAM instance profile to be attached to the TFE EC2 instance(s). Leave the value null to create a new one."
+  type        = string
+}
+
+variable "existing_iam_instance_role_name" {
+  type        = string
+  description = "The IAM role to associate with the instance profile. To create a new role, this value should be null."
+}
+
 variable "friendly_name_prefix" {
   type        = string
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
@@ -16,7 +26,7 @@ variable "friendly_name_prefix" {
 
 variable "iam_role_policy_arns" {
   default     = []
-  description = "A set of Amazon Resource Names of IAM role policys to be attached to the TFE IAM role."
+  description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."
   type        = set(string)
 }
 

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 resource "random_string" "friendly_name" {
   length  = 4
   upper   = false # Some AWS resources do not accept uppercase characters.
-  number  = false
+  numeric = false
   special = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -320,6 +320,18 @@ variable "network_public_subnets" {
 
 # TFE Instance(s)
 # ---------------
+variable "existing_iam_instance_profile_name" {
+  default     = null
+  description = "The IAM instance profile to be attached to the TFE EC2 instance(s). Leave the value null to create a new one."
+  type        = string
+}
+
+variable "existing_iam_instance_role_name" {
+  default     = null
+  description = "The IAM role to associate with the instance profile. Leave the value null to create a new one."
+  type        = string
+}
+
 variable "iam_role_policy_arns" {
   default     = []
   description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."


### PR DESCRIPTION
## Background

Closes Issue #284 
Jira [TFE-344](https://hashicorp.atlassian.net/browse/TFE-344)

This branch allows for the user to bring their own existing IAM instance profile and/or an IAM role used for the instance profile. The new variables that enable this behavior are:
- `existing_iam_instance_profile_name`
- `existing_iam_instance_role_name`

## How Has This Been Tested

I tested this locally by passing the new variables into my test module. I looked in the AWS portal to confirm that the Autoscaling Launch Configuration's IAM instance profile was the same one that I passed in.

I will also ensure that a passing test is run from the comments to ensure this doesn't break existing functionality.

[TFE-344]: https://hashicorp.atlassian.net/browse/TFE-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ