### PR TITLE
TF-5832

### DIFF
--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -5,6 +5,13 @@ resource "aws_s3_bucket" "tfe_data_bucket" {
   bucket        = "${var.friendly_name_prefix}-tfe-data"
   force_destroy = true
 }
+resource "aws_s3_bucket_ownership_controls" "tfe_data_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.tfe_data_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
 
 resource "aws_s3_bucket_acl" "tfe_data_bucket_acl" {
   bucket = aws_s3_bucket.tfe_data_bucket.id

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -14,6 +14,8 @@ resource "aws_s3_bucket_ownership_controls" "tfe_data_bucket_ownership_controls"
 }
 
 resource "aws_s3_bucket_acl" "tfe_data_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.tfe_data_bucket_ownership_controls]
+
   bucket = aws_s3_bucket.tfe_data_bucket.id
   acl    = "private"
 }


### PR DESCRIPTION
## Background

AWS released [information](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) that, as a default, they would be enabling S3 Block Public Access and disabling the access control lists for all new buckets as of April 2023. The change of functionality was also listed in the Terraform AWS provider, specifically the [aws_s3_bucket resource](https://registry.terraform.io/providers/hashicorp/aws/4.63.0/docs/resources/s3_bucket). You can also follow the GitHub issue [here](https://github.com/hashicorp/terraform-provider-aws/issues/28353).


Relates OR Closes [TF-5832](https://hashicorp.atlassian.net/browse/TF-5832?atlOrigin=eyJpIjoiMjY5M2NiZTRlMThkNGQ0Y2IzZDhmMDZmMzUxNjE0MTEiLCJwIjoiaiJ9)


## How Has This Been Tested

- Go to [ptfe-replicated](https://www.github.com/hashicorp/ptfe-replicated)
- Navigate to Actions and the `CI`
- Change the branch from main to `tf-5832`
- Run the failing AWS test
- Print the output in slack and here

## This PR makes me feel

![Jordan Shrug](https://media.giphy.com/media/Wp1SpsnWTPWwwXaoSV/giphy.gif)


[TF-5832]: https://hashicorp.atlassian.net/browse/TF-5832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ