### PR TITLE
add consolidated_services var to tests

### DIFF
--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -80,10 +80,11 @@ module "tfe" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                   = data.aws_ami.rhel.id
-  distribution             = "rhel"
   aws_access_key_id        = var.aws_access_key_id
   aws_secret_access_key    = var.aws_secret_access_key
   ca_certificate_secret_id = data.aws_secretsmanager_secret.ca_certificate.arn
+  consolidated_services    = var.consolidated_services
+  distribution             = "rhel"
   iact_subnet_list         = ["0.0.0.0/0"]
   iam_role_policy_arns     = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type            = "m5.xlarge"
@@ -95,7 +96,6 @@ module "tfe" {
   proxy_ip                 = module.test_proxy.proxy_ip
   proxy_port               = local.http_proxy_port
   tfe_subdomain            = local.test_name
-  consolidated_services    = var.consolidated_services
 
   asg_tags = local.common_tags
 }

--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -31,6 +31,12 @@ variable "ca_private_key_secret_name" {
   description = "The secrets manager secret name of the Base64 encoded CA private key."
 }
 
+variable "consolidated_services" {
+  default     = false
+  type        = bool
+  description = "(Required) True if TFE uses consolidated services."
+}
+
 variable "domain_name" {
   type        = string
   description = "Domain for creating the Terraform Enterprise subdomain on."
@@ -57,10 +63,4 @@ variable "tfe_license_secret_id" {
   default     = null
   type        = string
   description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
-}
-
-variable "consolidated_services" {
-  default     = false
-  type        = bool
-  description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -51,6 +51,7 @@ module "private_active_active" {
 
   ami_id                      = data.aws_ami.rhel.id
   distribution                = "rhel"
+  consolidated_services       = var.consolidated_services
   iact_subnet_list            = ["0.0.0.0/0"]
   iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.4xlarge"

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -11,6 +11,12 @@ variable "aws_role_arn" {
   description = "The AWS Role ARN to assume for this module."
 }
 
+variable "consolidated_services" {
+  default     = false
+  type        = bool
+  description = "(Required) True if TFE uses consolidated services."
+}
+
 variable "domain_name" {
   type        = string
   description = "Domain for creating the Terraform Enterprise subdomain on."

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -53,8 +53,9 @@ module "private_tcp_active_active" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                      = data.aws_ami.rhel.id
-  distribution                = "rhel"
   ca_certificate_secret_id    = data.aws_secretsmanager_secret.ca_certificate.arn
+  consolidated_services       = var.consolidated_services
+  distribution                = "rhel"
   iact_subnet_list            = ["0.0.0.0/0"]
   iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type               = "m5.8xlarge"

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -26,6 +26,12 @@ variable "certificate_pem_secret_id" {
   description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
 }
 
+variable "consolidated_services" {
+  default     = false
+  type        = bool
+  description = "(Required) True if TFE uses consolidated services."
+}
+
 variable "domain_name" {
   type        = string
   description = "Domain for creating the Terraform Enterprise subdomain on."

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -43,6 +43,7 @@ module "public_active_active" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                      = data.aws_ami.ubuntu.id
+  consolidated_services       = var.consolidated_services
   iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list            = var.iact_subnet_list
   instance_type               = "m5.xlarge"

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -11,6 +11,12 @@ variable "aws_role_arn" {
   description = "The AWS Role ARN to assume for this module."
 }
 
+variable "consolidated_services" {
+  default     = false
+  type        = bool
+  description = "(Required) True if TFE uses consolidated services."
+}
+
 variable "domain_name" {
   type        = string
   description = "Domain for creating the Terraform Enterprise subdomain on."

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -50,6 +50,7 @@ module "standalone_vault" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   distribution          = "ubuntu"
 
+  consolidated_services       = var.consolidated_services
   iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list            = ["0.0.0.0/0"]
   instance_type               = "m5.xlarge"
@@ -61,7 +62,6 @@ module "standalone_vault" {
   redis_encryption_in_transit = false
   redis_use_password_auth     = false
   tfe_subdomain               = local.friendly_name_prefix
-  consolidated_services       = var.consolidated_services
 
   # Vault
   extern_vault_enable    = true

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -11,6 +11,12 @@ variable "aws_role_arn" {
   description = "The AWS Role ARN to assume for this module."
 }
 
+variable "consolidated_services" {
+  default     = false
+  type        = bool
+  description = "(Required) True if TFE uses consolidated services."
+}
+
 variable "domain_name" {
   type        = string
   description = "Domain for creating the Terraform Enterprise subdomain on."
@@ -32,10 +38,4 @@ variable "tfe_license_secret_id" {
   default     = null
   type        = string
   description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
-}
-
-variable "consolidated_services" {
-  default     = false
-  type        = bool
-  description = "(Required) True if TFE uses consolidated services."
 }


### PR DESCRIPTION
## Background

This branch adds the `consolidated_services` variable defaulted to `false` for the tests.

Any additional changes are simply alphabetizing.