### PR TITLE
revert default tags

### DIFF
--- a/tests/active-active-rhel7-proxy/locals.tf
+++ b/tests/active-active-rhel7-proxy/locals.tf
@@ -6,7 +6,7 @@ locals {
   common_tags = {
     Terraform   = "cloud"
     Environment = local.utility_module_test ? "tfe_modules_test" : "tfe_team_dev"
-    Description = local.test_name
+    Description = "Active/Active on RHEL with Proxy scenario deployed from CircleCI"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"

--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -5,7 +5,7 @@ locals {
   common_tags = {
     Terraform   = "cloud"
     Environment = "tfe_modules_test"
-    Description = local.test_name
+    Description = "Private Active/Active"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"

--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -6,7 +6,7 @@ locals {
   common_tags = {
     Terraform   = "cloud"
     Environment = "tfe_modules_test"
-    Description = local.test_name
+    Description = "Private TCP Active/Active"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"

--- a/tests/public-active-active/locals.tf
+++ b/tests/public-active-active/locals.tf
@@ -5,7 +5,7 @@ locals {
   common_tags = {
     Terraform   = "cloud"
     Environment = "tfe_modules_test"
-    Description = local.test_name
+    Description = "Public Active/Active"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"

--- a/tests/standalone-vault/locals.tf
+++ b/tests/standalone-vault/locals.tf
@@ -5,7 +5,7 @@ locals {
   common_tags = {
     Terraform   = "False"
     Environment = var.license_file == null ? "tfe_utilities_test" : "ptfe-replicated CI"
-    Description = local.test_name
+    Description = "Standalone Vault"
     Repository  = "hashicorp/terraform-aws-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"


### PR DESCRIPTION
## Background

Keep seeing this [error](https://github.com/hashicorp/ptfe-replicated/actions/runs/5136716538/jobs/9243871022#step:15:2327), so I'm hoping that [this fix](https://github.com/hashicorp/terraform-provider-aws/issues/19583#issuecomment-1563262107) fixes it. This branch was originally intended to update the aws provider to use the version where this fix exists, however, it would require fixing some deprecations, which is not in scope right now. Therefore I'm just reverting the tags to get unblocked.

## How Has This Been Tested

Will test in slash commands.
