### PR TITLE
upgrade redis to 7.0

### DIFF
--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -8,7 +8,7 @@ variable "active_active" {
 
 variable "kms_key_arn" {
   description = <<-EOD
-  The Amazon Resource Name of the KMS key which will be used by the Redis Elasticache replication group to encrypt data 
+  The Amazon Resource Name of the KMS key which will be used by the Redis Elasticache replication group to encrypt data
   at rest.
   EOD
   type        = string
@@ -16,7 +16,7 @@ variable "kms_key_arn" {
 
 variable "tfe_instance_sg" {
   description = <<-EOD
-  The identity of the security group attached to the TFE EC2 instance(s) which will be authorized to communicate with 
+  The identity of the security group attached to the TFE EC2 instance(s) which will be authorized to communicate with
   the Redis Elasticache replication group.
   EOD
   type        = string
@@ -24,7 +24,7 @@ variable "tfe_instance_sg" {
 
 variable "network_id" {
   description = <<-EOD
-  The identity of the VPC in which the security group attached to the Redis Elasticache replication group will be 
+  The identity of the VPC in which the security group attached to the Redis Elasticache replication group will be
   deployed.
   EOD
   type        = string
@@ -61,13 +61,13 @@ variable "cache_size" {
 
 variable "engine_version" {
   type        = string
-  default     = "5.0.6"
+  default     = "7.0"
   description = "Redis enginer version."
 }
 
 variable "parameter_group_name" {
   type        = string
-  default     = "default.redis5.0"
+  default     = "default.redis7"
   description = "Redis parameter group name."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,13 +117,13 @@ variable "redis_encryption_at_rest" {
 
 variable "redis_engine_version" {
   type        = string
-  default     = "5.0.6"
+  default     = "7.0"
   description = "Redis enginer version."
 }
 
 variable "redis_parameter_group_name" {
   type        = string
-  default     = "default.redis5.0"
+  default     = "default.redis7"
   description = "Redis parameter group name."
 }
 


### PR DESCRIPTION
## Background

This pull request upgrades the default Redis version to v7.0. This is because 5.0 will stop being an officially supported version in TFE.
