### PR TITLE
update pg minor version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,7 @@ variable "db_size" {
 
 variable "postgres_engine_version" {
   type        = string
-  default     = "12.8"
+  default     = "12.15"
   description = "PostgreSQL version."
 }
 


### PR DESCRIPTION
## Background

All of [these tests](https://github.com/hashicorp/ptfe-replicated/actions/runs/5535123214) are failing (re: [TF-6907](https://hashicorp.atlassian.net/browse/TF-6907)) because of the postgres version:
```
│ Error: creating RDS DB Instance (bhfw-tfe20230712210155256500000006): InvalidParameterCombination: Cannot find version 12.8 for postgres
```

This branch updates the postgres minor version to the latest patch number in the Release calendar for Amazon RDS for PostgreSQL page [here](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html).

## How Has This Been Tested

- [ ] Tests pass before merging


[TF-6907]: https://hashicorp.atlassian.net/browse/TF-6907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ