### PR TITLE
use reusable workflows

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -5,177 +5,207 @@ on:
     types:
       - destroy-command
 
+env:
+  AWS_DEFAULT_REGION: us-east-2
+
 jobs:
+  active_active_rhel7_proxy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Active/Active RHEL7 Proxy
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'active-active-rhel7-proxy') }}
+    with:
+      cloud: AWS
+      test_name: Active/Active RHEL7 Proxy
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/active-active-rhel7-proxy
+      TFC_token_secret_name: ACTIVE_ACTIVE_RHEL7_PROXY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-active-active-rhel7-proxy"\n\
+          }\n\
+        }\n/'
+
   public_active_active:
-    name: Destroy resources from Public Active/Active
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Public Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/public-active-active
-      AWS_DEFAULT_REGION: us-east-2
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
-
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -input=false -no-color
-
-      - name: Terraform Destroy
-        id: destroy
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Public Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+    with:
+      cloud: AWS
+      test_name: Public Active/Active
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/public-active-active
+      TFC_token_secret_name: PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN
 
   private_active_active:
-    name: Destroy resources from Private Active/Active
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Private Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/private-active-active
-      AWS_DEFAULT_REGION: us-east-2
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
-
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -input=false -no-color
-
-      - name: Terraform Destroy
-        id: destroy
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Private Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+    with:
+      cloud: AWS
+      test_name: Private Active/Active
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-active-active
+      TFC_token_secret_name: PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN
 
   private_tcp_active_active:
-    name: Destroy resources from Private TCP Active/Active
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Private TCP Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/private-tcp-active-active
-      AWS_DEFAULT_REGION: us-east-2
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+    with:
+      cloud: AWS
+      test_name: Private TCP Active/Active
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-tcp-active-active
+      TFC_token_secret_name: PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN
 
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+  standalone_vault:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Standalone Vault
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-vault') }}
+    with:
+      cloud: AWS
+      test_name: Standalone Vault
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/standalone-vault
+      TFC_token_secret_name: STANDALONE_VAULT_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-standalone-vault"\n\
+          }\n\
+        }\n/'
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
+  active_active_rhel7_proxy_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Active/Active RHEL7 Proxy (Legacy)
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'active-active-rhel7-proxy-legacy') }}
+    with:
+      cloud: AWS
+      test_name: Active/Active RHEL7 Proxy (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/active-active-rhel7-proxy
+      TFC_token_secret_name: ACTIVE_ACTIVE_RHEL7_PROXY_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-active-active-rhel7-proxy-legacy"\n\
+          }\n\
+        }\n/'
 
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -input=false -no-color
+  public_active_active_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Public Active/Active (Legacy)
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active-legacy') }}
+    with:
+      cloud: AWS
+      test_name: Public Active/Active (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/public-active-active
+      TFC_token_secret_name: PUBLIC_ACTIVE_ACTIVE_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: s/aws-public-active-active/aws-public-active-active-legacy/
 
-      - name: Terraform Destroy
-        id: destroy
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
+  private_active_active_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Private Active/Active (Legacy)
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active-legacy') }}
+    with:
+      cloud: AWS
+      test_name: Private Active/Active (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-active-active
+      TFC_token_secret_name: PRIVATE_ACTIVE_ACTIVE_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: s/aws-private-active-active/aws-private-active-active-legacy/
 
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Private TCP Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+  private_tcp_active_active_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Private TCP Active/Active (Legacy)
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active-legacy') }}
+    with:
+      cloud: AWS
+      test_name: Private TCP Active/Active (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-tcp-active-active
+      TFC_token_secret_name: PRIVATE_TCP_ACTIVE_ACTIVE_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: s/aws-private-tcp-active-active/aws-private-tcp-active-active-legacy/
 
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+  standalone_vault_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@ah/tf-5370
+    secrets: inherit
+    name: Destroy resources from AWS Standalone Vault (Legacy)
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active-legacy') }}
+    with:
+      cloud: AWS
+      test_name: Standalone Vault (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/standalone-vault
+      TFC_token_secret_name: STANDALONE_VAULT_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-standalone-vault-legacy"\n\
+          }\n\
+        }\n/'

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -26,9 +26,18 @@ jobs:
             > | /help | Shows this help message |
             
             ## Test Case Names
-            
-            * private-active-active
-            * private-tcp-active-active
-            * public-active-active
+
+            FDO:
+              * active-active-rhel7-proxy
+              * private-active-active
+              * private-tcp-active-active
+              * public-active-active
+              * standalone-vault
+              Legacy:
+              * active-active-rhel7-proxy-legacy
+              * private-active-active-legacy
+              * private-tcp-active-active-legacy
+              * public-active-active-legacy
+              * standalone-vault-legacy
 
           reaction-type: confused

--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -33,7 +33,8 @@ jobs:
               * private-tcp-active-active
               * public-active-active
               * standalone-vault
-              Legacy:
+
+            Legacy:
               * active-active-rhel7-proxy-legacy
               * private-active-active-legacy
               * private-tcp-active-active-legacy

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -5,639 +5,209 @@ on:
     types:
       - test-command
 
+env:
+  AWS_DEFAULT_REGION: us-east-2
+
 jobs:
+  active_active_rhel7_proxy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Active/Active RHEL7 Proxy Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'active-active-rhel7-proxy') }}
+    with:
+      test_name: Active/Active RHEL7 Proxy
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/active-active-rhel7-proxy
+      TFC_token_secret_name: ACTIVE_ACTIVE_RHEL7_PROXY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-active-active-rhel7-proxy"\n\
+          }\n\
+        }\n/'
+
   public_active_active:
-    name: Run tf-test on Public Active/Active
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Public Active/Active Scenario
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/public-active-active
-      K6_WORK_DIR_PATH: ./tests/tfe-load-test
-      AWS_DEFAULT_REGION: us-east-2
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      # Checkout the hashicorp/tfe-load-test repository
-      - name: Checkout TFE Load Test
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          path: ${{ env.K6_WORK_DIR_PATH }}
-          repository: hashicorp/tfe-load-test
-          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-          persist-credentials: false
-
-      - name: Install required tools
-        working-directory: ${{ env.K6_WORK_DIR_PATH }}
-        env:
-          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-        run: |
-          sudo apt-get install jq
-          curl -L $K6_URL | tar -xz --strip-components=1
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
-
-      # Run Terraform commands between these comments vvv
-
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -input=false -no-color
-
-      - name: Terraform Validate
-        id: validate
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform validate -no-color
-
-      - name: Write GitHub Actions runner CIDR to Terraform Variables
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          echo "iact_subnet_list = [\"$( dig +short @resolver1.opendns.com myip.opendns.com )/32\"]" > github.auto.tfvars
-
-      - name: Terraform Apply
-        id: apply
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform apply -auto-approve -input=false -no-color
-
-      - name: Retrieve Health Check URL
-        id: retrieve-health-check-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw health_check_url
-
-      - name: Wait For TFE
-        id: wait-for-tfe
-        timeout-minutes: 15
-        env:
-          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-        run: |
-          echo "Curling \`health_check_url\` for a return status of 200..."
-          while ! curl -sfS --max-time 5 "$HEALTH_CHECK_URL"; do sleep 5; done
-
-      - name: Retrieve TFE URL
-        id: retrieve-tfe-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw tfe_url
-
-      - name: Retrieve IACT URL
-        id: retrieve-iact-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw iact_url
-
-      - name: Retrieve IACT
-        id: retrieve-iact
-        env:
-          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
-        run: |
-          token=$(curl --fail --retry 5 --verbose "$IACT_URL")
-          echo "::set-output name=token::$token"
-
-      - name: Retrieve Initial Admin User URL
-        id: retrieve-initial-admin-user-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw initial_admin_user_url
-
-      - name: Create Admin in TFE
-        id: create-admin
-        env:
-          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-          IACT: ${{ steps.retrieve-iact.outputs.token }}
-        run: |
-          echo \
-            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-            > ./payload.json
-          response=$( \
-            curl \
-            --fail \
-            --retry 5 \
-            --verbose \
-            --header 'Content-Type: application/json' \
-            --data @./payload.json \
-            "$IAU_URL"?token="$IACT")
-          echo "::set-output name=response::$response"
-
-      - name: Retrieve Admin Token
-        id: retrieve-admin-token
-        env:
-          RESPONSE: ${{ steps.create-admin.outputs.response }}
-        run: |
-          token=$(echo "$RESPONSE" | jq --raw-output '.token')
-          echo "::set-output name=token::$token"
-
-      - name: Run k6 Smoke Test
-        id: run-smoke-test
-        working-directory: ${{ env.K6_WORK_DIR_PATH }}
-        env:
-          K6_PATHNAME: "./k6"
-          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-          TFE_EMAIL: tf-onprem-team@hashicorp.com
-        run: |
-          make smoke-test
-
-      - name: Terraform Destroy
-        id: destroy
-        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      # Run Terraform commands between these comments ^^^
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Public Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
+    with:
+      test_name: Public Active/Active
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/public-active-active
+      TFC_token_secret_name: PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN
 
   private_active_active:
-    name: Run tf-test on Private Active/Active
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Private Active/Active Scenario
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/private-active-active
-      K6_WORK_DIR_PATH: ./tests/tfe-load-test
-      AWS_DEFAULT_REGION: us-east-2
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      # Checkout the hashicorp/tfe-load-test repository
-      - name: Checkout TFE Load Test
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          path: ${{ env.K6_WORK_DIR_PATH }}
-          repository: hashicorp/tfe-load-test
-          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-          persist-credentials: false
-
-      - name: Install required tools
-        working-directory: ${{ env.K6_WORK_DIR_PATH }}
-        env:
-          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-        run: |
-          sudo apt-get install jq
-          curl -L $K6_URL | tar -xz --strip-components=1
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
-
-      # Run Terraform commands between these comments vvv
-
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -input=false -no-color
-
-      - name: Terraform Validate
-        id: validate
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform validate -no-color
-
-      - name: Terraform Apply
-        id: apply
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform apply -auto-approve -input=false -no-color
-
-      - name: Retrieve Health Check URL
-        id: retrieve-health-check-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw health_check_url
-
-      - name: Retrieve Instance ID
-        id: retrieve-instance-id
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw proxy_instance_id
-
-      - name: Write Private SSH Key
-        env:
-          SSH_KEY_BASE64: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_SSH_KEY_BASE64 }}
-        run: |
-          echo "$SSH_KEY_BASE64" | base64 --decode > ./ssh-key.pem
-          chmod 0400 ./ssh-key.pem
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
-        with:
-          aws-access-key-id: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-          role-to-assume: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 2400
-          role-skip-session-tagging: true
-
-      - name: Start SOCKS5 Proxy
-        env:
-          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
-        run: |
-          aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
-          ssh \
-            -o 'BatchMode yes' \
-            -o 'StrictHostKeyChecking accept-new' \
-            -o 'ProxyCommand sh -c \
-              "aws ssm start-session \
-                --target %h \
-                --document-name AWS-StartSSHSession \
-                --parameters \"portNumber=%p\""' \
-            -i ./ssh-key.pem \
-            -f -N -p 22 -D localhost:5000 \
-            ubuntu@"$INSTANCE_ID"
-
-      - name: Wait For TFE
-        id: wait-for-tfe
-        timeout-minutes: 15
-        env:
-          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-        run: |
-          echo "Curling \`health_check_url\` for a return status of 200..."
-          while ! curl \
-            -sfS --max-time 5 --proxy socks5://localhost:5000 \
-            $HEALTH_CHECK_URL; \
-            do sleep 5; done
-
-      - name: Retrieve TFE URL
-        id: retrieve-tfe-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw tfe_url
-
-      - name: Retrieve IACT URL
-        id: retrieve-iact-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw iact_url
-
-      - name: Retrieve IACT
-        id: retrieve-iact
-        env:
-          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
-        run: |
-          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL")
-          echo "::set-output name=token::$token"
-
-      - name: Retrieve Initial Admin User URL
-        id: retrieve-initial-admin-user-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw initial_admin_user_url
-
-      - name: Create Admin in TFE
-        id: create-admin
-        env:
-          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-          IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
-        run: |
-          echo \
-            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-            > ./payload.json
-          response=$( \
-            curl \
-            --fail \
-            --retry 5 \
-            --verbose \
-            --header 'Content-Type: application/json' \
-            --data @./payload.json \
-            --proxy socks5://localhost:5000 \
-            "$IAU_URL"?token="$IACT_TOKEN")
-          echo "::set-output name=response::$response"
-
-      - name: Retrieve Admin Token
-        id: retrieve-admin-token
-        env:
-          RESPONSE: ${{ steps.create-admin.outputs.response }}
-        run: |
-          token=$(echo "$RESPONSE" | jq --raw-output '.token')
-          echo "::set-output name=token::$token"
-
-      - name: Run k6 Smoke Test
-        id: run-smoke-test
-        working-directory: ${{ env.K6_WORK_DIR_PATH }}
-        env:
-          K6_PATHNAME: "./k6"
-          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-          TFE_EMAIL: tf-onprem-team@hashicorp.com
-          http_proxy: socks5://localhost:5000/
-          https_proxy: socks5://localhost:5000/
-        run: |
-          make smoke-test
-
-      - name: Terraform Destroy
-        id: destroy
-        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      # Run Terraform commands between these comments ^^^
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Private Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
+    with:
+      test_name: Private Active/Active
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-active-active
+      TFC_token_secret_name: PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN
 
   private_tcp_active_active:
-    name: Run tf-test on Private TCP Active/Active
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Private TCP Active/Active Scenario
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/private-tcp-active-active
-      K6_WORK_DIR_PATH: ./tests/tfe-load-test
-      AWS_DEFAULT_REGION: us-east-2
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+    with:
+      test_name: Private TCP Active/Active
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-tcp-active-active
+      TFC_token_secret_name: PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN
 
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+  standalone_vault:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Standalone Vault Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-vault') }}
+    with:
+      test_name: Standalone Vault
+      utility_test: false
+      is_legacy_deployment: false
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/standalone-vault
+      first_apply_args: "-target=module.hcp_vault.hcp_vault_cluster.test -target=module.hcp_vault.hcp_vault_cluster_admin_token.test"
+      TFC_token_secret_name: STANDALONE_VAULT_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-standalone-vault"\n\
+          }\n\
+        }\n/'
 
-      # Checkout the hashicorp/tfe-load-test repository
-      - name: Checkout TFE Load Test
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          path: ${{ env.K6_WORK_DIR_PATH }}
-          repository: hashicorp/tfe-load-test
-          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-          persist-credentials: false
+  active_active_rhel7_proxy_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Active/Active RHEL7 Proxy (Legacy) Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'active-active-rhel7-proxy-legacy') }}
+    with:
+      test_name: Active/Active RHEL7 Proxy (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/active-active-rhel7-proxy
+      TFC_token_secret_name: ACTIVE_ACTIVE_RHEL7_PROXY_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-active-active-rhel7-proxy-legacy"\n\
+          }\n\
+        }\n/'
 
-      - name: Install required tools
-        working-directory: ${{ env.K6_WORK_DIR_PATH }}
-        env:
-          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-        run: |
-          sudo apt-get install jq
-          curl -L $K6_URL | tar -xz --strip-components=1
+  public_active_active_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Public Active/Active (Legacy) Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active-legacy') }}
+    with:
+      test_name: Public Active/Active (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/public-active-active
+      TFC_token_secret_name: PUBLIC_ACTIVE_ACTIVE_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: s/aws-public-active-active/aws-public-active-active-legacy/
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN }}
-          terraform_version: 0.14.8
-          terraform_wrapper: true
+  private_active_active_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Private Active/Active (Legacy) Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active-legacy') }}
+    with:
+      test_name: Private Active/Active (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-active-active
+      TFC_token_secret_name: PRIVATE_ACTIVE_ACTIVE_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: s/aws-private-active-active/aws-private-active-active-legacy/
 
-      # Run Terraform commands between these comments vvv
+  private_tcp_active_active_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Private TCP Active/Active (Legacy) Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active-legacy') }}
+    with:
+      test_name: Private TCP Active/Active (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/private-tcp-active-active
+      TFC_token_secret_name: PRIVATE_TCP_ACTIVE_ACTIVE_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: s/aws-private-tcp-active-active/aws-private-tcp-active-active-legacy/
 
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -input=false -no-color
-
-      - name: Terraform Validate
-        id: validate
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform validate -no-color
-
-      - name: Terraform Apply
-        id: apply
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform apply -auto-approve -input=false -no-color
-
-      - name: Retrieve Health Check URL
-        id: retrieve-health-check-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw health_check_url
-
-      - name: Retrieve Instance ID
-        id: retrieve-instance-id
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw proxy_instance_id
-
-      - name: Write Private TCP SSH Key
-        env:
-          SSH_KEY_BASE64: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_SSH_KEY_BASE64 }}
-        run: |
-          echo "$SSH_KEY_BASE64" | base64 --decode > ./ssh-key.pem
-          chmod 0400 ./ssh-key.pem
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
-        with:
-          aws-access-key-id: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-          role-to-assume: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 2400
-          role-skip-session-tagging: true
-
-      - name: Start SOCKS5 Proxy
-        env:
-          INSTANCE_ID: ${{ steps.retrieve-instance-id.outputs.stdout }}
-        run: |
-          aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
-          ssh \
-            -o 'BatchMode yes' \
-            -o 'StrictHostKeyChecking accept-new' \
-            -o 'ServerAliveInterval 5' \
-            -o 'ServerAliveCountMax 3' \
-            -o 'ProxyCommand sh -c \
-              "aws ssm start-session \
-                --target %h \
-                --document-name AWS-StartSSHSession \
-                --parameters \"portNumber=%p\""' \
-            -i ./ssh-key.pem \
-            -f -N -p 22 -D localhost:5000 \
-            ubuntu@"$INSTANCE_ID"
-
-      - name: Wait For TFE
-        id: wait-for-tfe
-        timeout-minutes: 20
-        env:
-          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-        run: |
-          echo "Curling \`health_check_url\` for a return status of 200..."
-          while ! curl \
-            --connect-timeout 10 \
-            -sfS --max-time 5 --proxy socks5://localhost:5000 \
-            --verbose \
-            $HEALTH_CHECK_URL; \
-            do sleep 5; done
-
-      - name: Retrieve TFE URL
-        id: retrieve-tfe-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw tfe_url
-
-      - name: Retrieve IACT URL
-        id: retrieve-iact-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw iact_url
-
-      - name: Retrieve IACT
-        id: retrieve-iact
-        env:
-          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
-        run: |
-          token=$( \
-            curl --fail --retry 5 --verbose \
-            --connect-timeout 10 \
-            --proxy socks5://localhost:5000 "$IACT_URL")
-          echo "::set-output name=token::$token"
-
-      - name: Retrieve Initial Admin User URL
-        id: retrieve-initial-admin-user-url
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          terraform output -no-color -raw initial_admin_user_url
-
-      - name: Create Admin in TFE
-        id: create-admin
-        env:
-          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-          IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
-        run: |
-          echo \
-            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-            > ./payload.json
-          response=$( \
-            curl \
-            --connect-timeout 10 \
-            --fail \
-            --retry 5 \
-            --verbose \
-            --header 'Content-Type: application/json' \
-            --data @./payload.json \
-            --proxy socks5://localhost:5000 \
-            "$IAU_URL"?token="$IACT_TOKEN")
-          echo "::set-output name=response::$response"
-
-      - name: Retrieve Admin Token
-        id: retrieve-admin-token
-        env:
-          RESPONSE: ${{ steps.create-admin.outputs.response }}
-        run: |
-          token=$(echo "$RESPONSE" | jq --raw-output '.token')
-          echo "::set-output name=token::$token"
-
-      - name: Run k6 Smoke Test
-        id: run-smoke-test
-        working-directory: ${{ env.K6_WORK_DIR_PATH }}
-        env:
-          K6_PATHNAME: "./k6"
-          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-          TFE_EMAIL: tf-onprem-team@hashicorp.com
-          http_proxy: socks5://localhost:5000/
-          https_proxy: socks5://localhost:5000/
-        run: |
-          make smoke-test
-
-      - name: Terraform Destroy
-        id: destroy
-        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      # Run Terraform commands between these comments ^^^
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Private TCP Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
+  standalone_vault_legacy:
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-5370
+    secrets: inherit
+    name: Test AWS Standalone Vault (Legacy) Scenario
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active-legacy') }}
+    with:
+      test_name: Standalone Vault (Legacy)
+      utility_test: false
+      is_legacy_deployment: true
+      module_repository_id: hashicorp/terraform-aws-terraform-enterprise
+      k6_work_dir: ./tests/tfe-load-test
+      pull_request_repo_name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      pull_request_ref: ${{ github.event.client_payload.pull_request.head.sha }}
+      pull_request_comment_id: ${{ github.event.client_payload.github.payload.comment.id }}
+      work_dir: ./tests/standalone-vault
+      first_apply_args: "-target=module.hcp_vault.hcp_vault_cluster.test -target=module.hcp_vault.hcp_vault_cluster_admin_token.test"
+      TFC_token_secret_name: STANDALONE_VAULT_LEGACY_TFC_TOKEN
+      TFC_workspace_substitution_pattern: 's/terraform {/terraform {\n\
+        backend "remote" {\n\
+          organization = "terraform-enterprise-modules-test"\n\
+          workspaces {\n\
+            name = "aws-standalone-vault-legacy"\n\
+          }\n\
+        }\n/'


### PR DESCRIPTION
## Background

[Jira TF-8609](https://hashicorp.atlassian.net/browse/TF-8609)
#299 

This branch changes the test workflows to use the reusable workflows created in [this branch of the `terraform-random-tfe-utilities`](https://github.com/hashicorp/terraform-random-tfe-utility/pull/118) repo.

The changes in this branch can only be tested with the [branch of this repo that includes the FDO deployments](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/299). 

## How ~Has~ _Will_ This Been Tested

Therefore, I will proceed with the following:

- [ ] Merge this PR to `main` as it has no implications of any other repos.
- [ ] After this merges, I will merge `main` into [this branch](https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/299) and proceed to run the `/test` commands
