### PR TITLE
enable FDO Docker deployment

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   active_active_rhel7_proxy:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Active/Active RHEL7 Proxy Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'active-active-rhel7-proxy' }}
@@ -34,7 +34,7 @@ jobs:
         }\n/'
 
   public_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Public Active/Active Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'public-active-active' }}
@@ -51,7 +51,7 @@ jobs:
       TFC_token_secret_name: PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN
 
   private_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Private Active/Active Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-active-active' }}
@@ -72,7 +72,7 @@ jobs:
       aws_role_to_assume: PRIVATE_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME
 
   private_tcp_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Private TCP Active/Active Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-tcp-active-active' }}
@@ -93,7 +93,7 @@ jobs:
       aws_role_to_assume: PRIVATE_TCP_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME
 
   standalone_vault:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Standalone Vault Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-vault' }}
@@ -118,7 +118,7 @@ jobs:
         }\n/'
 
   active_active_rhel7_proxy_replicated:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Active/Active RHEL7 Proxy (Replicated) Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'active-active-rhel7-proxy-replicated' }}
@@ -142,7 +142,7 @@ jobs:
         }\n/'
 
   public_active_active_replicated:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Public Active/Active (Replicated) Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'public-active-active-replicated' }}
@@ -160,7 +160,7 @@ jobs:
       TFC_workspace_substitution_pattern: s/aws-public-active-active/aws-public-active-active-replicated/
 
   private_active_active_replicated:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Private Active/Active (Replicated) Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-active-active-replicated' }}
@@ -182,7 +182,7 @@ jobs:
       aws_role_to_assume: PRIVATE_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME
 
   private_tcp_active_active_replicated:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Private TCP Active/Active (Replicated) Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-tcp-active-active-replicated' }}
@@ -204,7 +204,7 @@ jobs:
       aws_role_to_assume: PRIVATE_TCP_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME
 
   standalone_vault_replicated:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@main
     secrets: inherit
     name: Test AWS Standalone Vault (Replicated) Scenario
     if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-vault-replicated' }}

--- a/examples/active-active-proxy/main.tf
+++ b/examples/active-active-proxy/main.tf
@@ -82,8 +82,6 @@ module "active_active" {
   redis_encryption_in_transit = true
   redis_use_password_auth     = true
   tfe_subdomain               = var.tfe_subdomain
-  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
   vm_certificate_secret_id    = var.certificate_pem_secret_id
   vm_key_secret_id            = var.private_key_pem_secret_id
 }

--- a/examples/standalone-airgap-dev/main.tf
+++ b/examples/standalone-airgap-dev/main.tf
@@ -59,8 +59,6 @@ module "standalone_airgap_dev" {
   # Bootstrapping resources
   airgap_url                                = var.airgap_url
   tfe_license_bootstrap_airgap_package_path = "/var/lib/ptfe/ptfe.airgap"
-  tls_bootstrap_cert_pathname               = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname                = "/var/lib/terraform-enterprise/key.pem"
   tfe_license_secret_id                     = module.secrets.tfe_license_secret_id
 
   # Standalone, External Mode, Airgapped Installation Example

--- a/examples/standalone-airgap/main.tf
+++ b/examples/standalone-airgap/main.tf
@@ -48,8 +48,6 @@ module "standalone_airgap" {
 
   # Bootstrapping resources
   tfe_license_bootstrap_airgap_package_path = "/var/lib/ptfe/ptfe.airgap"
-  tls_bootstrap_cert_pathname               = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname                = "/var/lib/terraform-enterprise/key.pem"
   tfe_license_secret_id                     = null
 
   # Standalone, External Mode, Airgapped Installation Example

--- a/locals.tf
+++ b/locals.tf
@@ -10,6 +10,7 @@ locals {
   enable_database_module       = local.enable_external
   enable_object_storage_module = local.enable_external
   enable_redis_module          = local.active_active
+  fdo_operational_mode         = local.enable_disk ? "disk" : local.active_active ? "active-active" : "external"
   ami_id                       = local.default_ami_id ? data.aws_ami.ubuntu.id : var.ami_id
   default_ami_id               = var.ami_id == null
   fqdn                         = "${var.tfe_subdomain}.${var.domain_name}"

--- a/locals.tf
+++ b/locals.tf
@@ -61,6 +61,7 @@ locals {
     "localhost",
     "s3.amazonaws.com",
     ".s3.amazonaws.com",
+    "s3.${data.aws_region.current.name}.amazonaws.com",
     local.fqdn,
     var.network_cidr
   ], var.no_proxy)

--- a/locals.tf
+++ b/locals.tf
@@ -59,6 +59,8 @@ locals {
     "download.docker.com",
     "centos.org",
     "localhost",
+    "s3.amazonaws.com",
+    ".s3.amazonaws.com",
     local.fqdn,
     var.network_cidr
   ], var.no_proxy)

--- a/locals.tf
+++ b/locals.tf
@@ -58,6 +58,7 @@ locals {
     "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
     "download.docker.com",
     "centos.org",
+    "localhost",
     local.fqdn,
     var.network_cidr
   ], var.no_proxy)

--- a/locals.tf
+++ b/locals.tf
@@ -56,6 +56,8 @@ locals {
     "169.254.169.254",
     ".aws.ce.redhat.com",
     "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
+    "download.docker.com",
+    "centos.org",
     local.fqdn,
     var.network_cidr
   ], var.no_proxy)

--- a/locals.tf
+++ b/locals.tf
@@ -51,6 +51,15 @@ locals {
     }
   )
 
+  no_proxy = concat([
+    "127.0.0.1",
+    "169.254.169.254",
+    ".aws.ce.redhat.com",
+    "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
+    local.fqdn,
+    var.network_cidr
+  ], var.no_proxy)
+
   trusted_proxies = concat(
     var.trusted_proxies,
     var.network_private_subnet_cidrs

--- a/main.tf
+++ b/main.tf
@@ -120,24 +120,30 @@ module "docker_compose_config" {
   source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/tf-8609-fdo-6"
   count  = var.is_replicated_deployment ? 0 : 1
 
+  tfe_license = var.hc_license
+
   hostname                  = local.fqdn
   http_port                 = var.http_port
   https_port                = var.https_port
-  tfe_license               = var.hc_license
+  http_proxy                = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null
+  https_proxy               = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null
+  no_proxy                  = local.no_proxy
   license_reporting_opt_out = var.license_reporting_opt_out
   operational_mode          = local.fdo_operational_mode
-  cert_file                 = "/etc/ssl/private/terraform-enterprise/cert.pem"
-  key_file                  = "/etc/ssl/private/terraform-enterprise/key.pem"
-  tfe_image                 = var.tfe_image
-  tls_ca_bundle_file        = "/etc/ssl/private/terraform-enterprise/bundle.pem"
-  tls_ciphers               = var.tls_ciphers
-  tls_version               = var.tls_version
-  run_pipeline_image        = var.run_pipeline_image
-  capacity_concurrency      = var.capacity_concurrency
-  capacity_cpu              = var.capacity_cpu
-  capacity_memory           = var.capacity_memory
-  iact_subnets              = join(",", var.iact_subnet_list)
-  iact_time_limit           = var.iact_subnet_time_limit
+
+  cert_file          = "/etc/ssl/private/terraform-enterprise/cert.pem"
+  key_file           = "/etc/ssl/private/terraform-enterprise/key.pem"
+  tfe_image          = var.tfe_image
+  tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
+  tls_ciphers        = var.tls_ciphers
+  tls_version        = var.tls_version
+
+  capacity_concurrency = var.capacity_concurrency
+  capacity_cpu         = var.capacity_cpu
+  capacity_memory      = var.capacity_memory
+  iact_subnets         = join(",", var.iact_subnet_list)
+  iact_time_limit      = var.iact_subnet_time_limit
+  run_pipeline_image   = var.run_pipeline_image
 
   database_name       = local.database.name
   database_user       = local.database.username
@@ -190,16 +196,9 @@ module "tfe_init_fdo" {
   certificate_secret_id    = var.vm_certificate_secret_id == null ? null : var.vm_certificate_secret_id
   key_secret_id            = var.vm_key_secret_id == null ? null : var.vm_key_secret_id
 
-  proxy_ip   = var.proxy_ip
-  proxy_port = var.proxy_port
-  extra_no_proxy = concat([
-    "127.0.0.1",
-    "169.254.169.254",
-    ".aws.ce.redhat.com",
-    "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
-    local.fqdn,
-    var.network_cidr
-  ], var.no_proxy)
+  proxy_ip       = var.proxy_ip
+  proxy_port     = var.proxy_port
+  extra_no_proxy = local.no_proxy
 
   registry_username   = var.registry_username
   registry_password   = var.registry_password

--- a/main.tf
+++ b/main.tf
@@ -350,9 +350,10 @@ module "vm" {
   ebs_iops                            = var.ebs_iops
   ebs_delete_on_termination           = var.ebs_delete_on_termination
   friendly_name_prefix                = var.friendly_name_prefix
-  key_name                            = var.key_name
+  health_check_grace_period           = var.health_check_grace_period
   instance_type                       = var.instance_type
   is_replicated_deployment            = var.is_replicated_deployment
+  key_name                            = var.key_name
   network_id                          = local.network_id
   network_subnets_private             = local.network_private_subnets
   network_private_subnet_cidrs        = local.network_private_subnet_cidrs

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,8 @@ module "docker_compose_config" {
   count  = var.is_replicated_deployment ? 0 : 1
 
   hostname                  = local.fqdn
+  http_port                 = var.http_port
+  https_port                = var.https_port
   tfe_license               = var.hc_license
   license_reporting_opt_out = var.license_reporting_opt_out
   operational_mode          = local.fdo_operational_mode

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,6 @@ module "docker_compose_config" {
   cert_file          = "/etc/ssl/private/terraform-enterprise/cert.pem"
   key_file           = "/etc/ssl/private/terraform-enterprise/key.pem"
   tfe_image          = var.tfe_image
-  tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
   tls_ciphers        = var.tls_ciphers
   tls_version        = var.tls_version
 

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ module "database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/tf-8609-fdo-6"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license
@@ -180,7 +180,7 @@ module "docker_compose_config" {
 # AWS cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # --------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/tf-8609-fdo-6"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "aws"

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,7 @@ module "docker_compose_config" {
   cert_file          = "/etc/ssl/private/terraform-enterprise/cert.pem"
   key_file           = "/etc/ssl/private/terraform-enterprise/key.pem"
   tfe_image          = var.tfe_image
+  tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
   tls_ciphers        = var.tls_ciphers
   tls_version        = var.tls_version
 

--- a/main.tf
+++ b/main.tf
@@ -124,8 +124,8 @@ module "docker_compose_config" {
   tfe_license               = var.hc_license
   license_reporting_opt_out = var.license_reporting_opt_out
   operational_mode          = local.fdo_operational_mode
-  cert_file                 = var.tls_bootstrap_cert_pathname
-  key_file                  = var.tls_bootstrap_key_pathname
+  cert_file                 = "/etc/ssl/private/terraform-enterprise/cert.pem"
+  key_file                  = "/etc/ssl/private/terraform-enterprise/key.pem"
   tfe_image                 = var.tfe_image
   tls_ca_bundle_file        = var.tls_ca_bundle_file
   tls_ciphers               = var.tls_ciphers

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,8 @@ module "docker_compose_config" {
   redis_use_tls  = local.redis.use_tls
   redis_use_auth = local.redis.use_password_auth
 
+  trusted_proxies = local.trusted_proxies
+
   vault_address   = var.extern_vault_addr
   vault_namespace = var.extern_vault_namespace
   vault_path      = var.extern_vault_path

--- a/main.tf
+++ b/main.tf
@@ -228,14 +228,7 @@ module "settings" {
   release_sequence              = var.release_sequence
   pg_extra_params               = var.pg_extra_params
 
-  extra_no_proxy = concat([
-    "127.0.0.1",
-    "169.254.169.254",
-    ".aws.ce.redhat.com",
-    "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
-    local.fqdn,
-    var.network_cidr
-  ], var.no_proxy)
+  extra_no_proxy = join(",", local.no_proxy)
 
   # Replicated Base Configuration
   hostname                                  = local.fqdn

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ module "docker_compose_config" {
   cert_file          = "/etc/ssl/private/terraform-enterprise/cert.pem"
   key_file           = "/etc/ssl/private/terraform-enterprise/key.pem"
   tfe_image          = var.tfe_image
-  tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
+  tls_ca_bundle_file = var.ca_certificate_secret_id != null ? "/etc/ssl/private/terraform-enterprise/bundle.pem" : null
   tls_ciphers        = var.tls_ciphers
   tls_version        = var.tls_version
 

--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,7 @@ module "settings" {
   release_sequence              = var.release_sequence
   pg_extra_params               = var.pg_extra_params
 
-  extra_no_proxy = join(",", local.no_proxy)
+  extra_no_proxy = local.no_proxy
 
   # Replicated Base Configuration
   hostname                                  = local.fqdn

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ module "docker_compose_config" {
   cert_file                 = "/etc/ssl/private/terraform-enterprise/cert.pem"
   key_file                  = "/etc/ssl/private/terraform-enterprise/key.pem"
   tfe_image                 = var.tfe_image
-  tls_ca_bundle_file        = var.tls_ca_bundle_file
+  tls_ca_bundle_file        = "/etc/ssl/private/terraform-enterprise/bundle.pem"
   tls_ciphers               = var.tls_ciphers
   tls_version               = var.tls_version
   run_pipeline_image        = var.run_pipeline_image

--- a/main.tf
+++ b/main.tf
@@ -117,13 +117,13 @@ module "database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/tf-8609-fdo-6"
   count  = var.is_replicated_deployment ? 0 : 1
 
   hostname                  = local.fqdn
   tfe_license               = var.hc_license
   license_reporting_opt_out = var.license_reporting_opt_out
-  operational_mode          = var.operational_mode
+  operational_mode          = local.fdo_operational_mode
   cert_file                 = var.tls_bootstrap_cert_pathname
   key_file                  = var.tls_bootstrap_key_pathname
   tfe_image                 = var.tfe_image
@@ -170,11 +170,11 @@ module "docker_compose_config" {
 # AWS cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # --------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/tf-8609-fdo-6"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "aws"
-  operational_mode  = var.operational_mode
+  operational_mode  = local.fdo_operational_mode
   custom_image_tag  = var.custom_image_tag
   enable_monitoring = var.enable_monitoring
 

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -9,6 +9,8 @@ locals {
     var.vm_key_secret_id
   ] : secret if secret != null]
 
+  create_secretsmanager_policy = var.ca_certificate_secret_id != null || var.tfe_license_secret_id != null || var.vm_certificate_secret_id != null || var.vm_key_secret_id != null && var.existing_iam_instance_profile_name == null && !var.enable_airgap
+
   iam_instance_role    = try(data.aws_iam_role.existing_instance_role[0], aws_iam_role.instance_role[0])
   iam_instance_profile = try(data.aws_iam_instance_profile.existing_instance_profile[0], aws_iam_instance_profile.tfe[0])
 }

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -9,8 +9,6 @@ locals {
     var.vm_key_secret_id
   ] : secret if secret != null]
 
-  # create_secretsmanager_policy = var.ca_certificate_secret_id != null || var.tfe_license_secret_id != null || var.vm_certificate_secret_id != null || var.vm_key_secret_id != null && var.existing_iam_instance_profile_name == null && !var.enable_airgap
-
   iam_instance_role    = try(data.aws_iam_role.existing_instance_role[0], aws_iam_role.instance_role[0])
   iam_instance_profile = try(data.aws_iam_instance_profile.existing_instance_profile[0], aws_iam_instance_profile.tfe[0])
 }

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -9,7 +9,7 @@ locals {
     var.vm_key_secret_id
   ] : secret if secret != null]
 
-  create_secretsmanager_policy = var.ca_certificate_secret_id != null || var.tfe_license_secret_id != null || var.vm_certificate_secret_id != null || var.vm_key_secret_id != null && var.existing_iam_instance_profile_name == null && !var.enable_airgap
+  # create_secretsmanager_policy = var.ca_certificate_secret_id != null || var.tfe_license_secret_id != null || var.vm_certificate_secret_id != null || var.vm_key_secret_id != null && var.existing_iam_instance_profile_name == null && !var.enable_airgap
 
   iam_instance_role    = try(data.aws_iam_role.existing_instance_role[0], aws_iam_role.instance_role[0])
   iam_instance_profile = try(data.aws_iam_instance_profile.existing_instance_profile[0], aws_iam_instance_profile.tfe[0])

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_iam_role_policy" "secretsmanager" {
-  count = var.existing_iam_instance_profile_name == null && !var.enable_airgap ? 1 : 0
+  count = var.existing_iam_instance_profile_name == null && !var.enable_airgap && local.secret_arns != [] ? 1 : 0
 
   policy = data.aws_iam_policy_document.secretsmanager[0].json
   role   = local.iam_instance_role.id

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -32,16 +32,7 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_iam_role_policy" "secretsmanager" {
-  count = (
-    var.existing_iam_instance_profile_name == null &&
-    !var.enable_airgap && (
-      var.ca_certificate_secret_id != null ||
-      var.tfe_license_secret_id != null ||
-      var.vm_certificate_secret_id != null ||
-      var.vm_key_secret_id != null
-    ) ?
-    1 : 0
-  )
+  count = var.existing_iam_instance_profile_name == null && !var.enable_airgap ? 1 : 0
 
   policy = data.aws_iam_policy_document.secretsmanager[0].json
   role   = local.iam_instance_role.id

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -32,7 +32,16 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_iam_role_policy" "secretsmanager" {
-  count = var.existing_iam_instance_profile_name == null && !var.enable_airgap && local.secret_arns != [] ? 1 : 0
+  count = (
+    var.existing_iam_instance_profile_name == null &&
+    !var.enable_airgap && (
+      var.ca_certificate_secret_id != null ||
+      var.tfe_license_secret_id != null ||
+      var.vm_certificate_secret_id != null ||
+      var.vm_key_secret_id != null
+    ) ?
+    1 : 0
+  )
 
   policy = data.aws_iam_policy_document.secretsmanager[0].json
   role   = local.iam_instance_role.id

--- a/modules/vm/locals.tf
+++ b/modules/vm/locals.tf
@@ -18,4 +18,6 @@ locals {
       }
     ]
   )
+  default_health_check_grace_period = var.default_ami_id ? 900 : 1500
+  health_check_grace_period         = var.health_check_grace_period != null ? var.health_check_grace_period : local.default_health_check_grace_period
 }

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -125,7 +125,7 @@ resource "aws_autoscaling_group" "tfe_asg" {
   ]
   # Increases grace period for any AMI that is not the default Ubuntu
   # since RHEL has longer startup time
-  health_check_grace_period = var.default_ami_id ? 900 : 1500
+  health_check_grace_period = local.health_check_grace_period
   health_check_type         = "ELB"
   launch_configuration      = aws_launch_configuration.tfe.name
 

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -31,21 +31,6 @@ variable "aws_iam_instance_profile" {
   type        = string
 }
 
-variable "network_id" {
-  description = "The identity of the VPC in which the security group attached to the TFE EC2 instance will be delpoyed."
-  type        = string
-}
-
-variable "network_subnets_private" {
-  description = "A list of the identities of the private subnetworks in which the EC2 autoscaling group will be deployed."
-  type        = list(string)
-}
-
-variable "instance_type" {
-  description = "The instance type of TFE EC2 instance(s) to create."
-  type        = string
-}
-
 variable "active_active" {
   type        = bool
   description = "Flag for active-active configuation: true for active-active, false for standalone"
@@ -66,9 +51,29 @@ variable "friendly_name_prefix" {
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
 }
 
+variable "health_check_grace_period" {
+  description = "The health grace period aws provides to allow for an instance to pass it's health check."
+  type        = number
+}
+
+variable "instance_type" {
+  description = "The instance type of TFE EC2 instance(s) to create."
+  type        = string
+}
+
 variable "is_replicated_deployment" {
   type        = bool
   description = "TFE will be installed using a Replicated license and deployment method."
+}
+
+variable "network_id" {
+  description = "The identity of the VPC in which the security group attached to the TFE EC2 instance will be delpoyed."
+  type        = string
+}
+
+variable "network_subnets_private" {
+  description = "A list of the identities of the private subnetworks in which the EC2 autoscaling group will be deployed."
+  type        = list(string)
 }
 
 variable "node_count" {

--- a/tests/active-active-rhel7-proxy/data.tf
+++ b/tests/active-active-rhel7-proxy/data.tf
@@ -24,7 +24,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
+    values = ["RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2"]
   }
 
   filter {

--- a/tests/active-active-rhel7-proxy/data.tf
+++ b/tests/active-active-rhel7-proxy/data.tf
@@ -9,6 +9,14 @@ data "aws_secretsmanager_secret" "ca_private_key" {
   name = var.ca_private_key_secret_name
 }
 
+data "aws_secretsmanager_secret" "vm_key" {
+  name = "wildcard-private-key-pem"
+}
+
+data "aws_secretsmanager_secret" "vm_certificate" {
+  name = "wildcard-chained-certificate-pem"
+}
+
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/active-active-rhel7-proxy/locals.tf
+++ b/tests/active-active-rhel7-proxy/locals.tf
@@ -19,5 +19,5 @@ locals {
   iam_principal         = data.aws_iam_user.ci_s3.arn
   load_balancing_scheme = "PUBLIC"
   http_proxy_port       = "3128"
-  utility_module_test   = var.license_file == null
+  utility_module_test   = (var.license_file == null && var.is_replicated_deployment)
 }

--- a/tests/active-active-rhel7-proxy/locals.tf
+++ b/tests/active-active-rhel7-proxy/locals.tf
@@ -17,7 +17,7 @@ locals {
   ssm_policy_arn        = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   test_name             = "${local.friendly_name_prefix}-test-active-active-rhel-proxy"
   iam_principal         = data.aws_iam_user.ci_s3.arn
-  load_balancing_scheme = "PUBLIC"
+  load_balancing_scheme = "PRIVATE_TCP"
   http_proxy_port       = "3128"
   utility_module_test   = (var.license_file == null && var.is_replicated_deployment)
 }

--- a/tests/active-active-rhel7-proxy/locals.tf
+++ b/tests/active-active-rhel7-proxy/locals.tf
@@ -17,7 +17,7 @@ locals {
   ssm_policy_arn        = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   test_name             = "${local.friendly_name_prefix}-test-active-active-rhel-proxy"
   iam_principal         = data.aws_iam_user.ci_s3.arn
-  load_balancing_scheme = "PRIVATE_TCP"
+  load_balancing_scheme = "PUBLIC"
   http_proxy_port       = "3128"
   utility_module_test   = (var.license_file == null && var.is_replicated_deployment)
 }

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -21,7 +21,7 @@ resource "random_string" "friendly_name" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = local.utility_module_test || !var.is_replicated_deployment ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -82,6 +82,7 @@ module "tfe" {
   ami_id                        = data.aws_ami.rhel.id
   aws_access_key_id             = var.aws_access_key_id
   aws_secret_access_key         = var.aws_secret_access_key
+  bypass_preflight_checks       = true
   ca_certificate_secret_id      = data.aws_secretsmanager_secret.ca_certificate.arn
   consolidated_services_enabled = var.consolidated_services_enabled
   distribution                  = "rhel"

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -99,6 +99,10 @@ module "tfe" {
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false
   tfe_subdomain                 = local.test_name
+  tls_bootstrap_cert_pathname   = "/etc/ssl/private/terraform-enterprise/cert.pem"
+  tls_bootstrap_key_pathname    = "/etc/ssl/private/terraform-enterprise/key.pem"
+  vm_certificate_secret_id      = data.aws_secretsmanager_secret.vm_certificate.id
+  vm_key_secret_id              = data.aws_secretsmanager_secret.vm_key.id
 
   asg_tags = local.common_tags
 

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -99,8 +99,6 @@ module "tfe" {
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false
   tfe_subdomain                 = local.test_name
-  tls_bootstrap_cert_pathname   = "/etc/ssl/private/terraform-enterprise/cert.pem"
-  tls_bootstrap_key_pathname    = "/etc/ssl/private/terraform-enterprise/key.pem"
   vm_certificate_secret_id      = data.aws_secretsmanager_secret.vm_certificate.id
   vm_key_secret_id              = data.aws_secretsmanager_secret.vm_key.id
 

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -85,6 +85,7 @@ module "tfe" {
   ca_certificate_secret_id      = data.aws_secretsmanager_secret.ca_certificate.arn
   consolidated_services_enabled = var.consolidated_services_enabled
   distribution                  = "rhel"
+  health_check_grace_period     = 3000
   iact_subnet_list              = ["0.0.0.0/0"]
   iam_role_policy_arns          = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type                 = "m5.xlarge"

--- a/tests/active-active-rhel7-proxy/outputs.tf
+++ b/tests/active-active-rhel7-proxy/outputs.tf
@@ -17,6 +17,11 @@ output "ptfe_endpoint" {
   description = "Terraform Enterprise Application URL"
 }
 
+output "tfe_url" {
+  value       = module.tfe.tfe_url
+  description = "The URL to the TFE application."
+}
+
 # Change this to health_check_url for consistency. This requires changing it in ptfe-replicated tests.
 output "ptfe_health_check" {
   value       = module.tfe.health_check_url

--- a/tests/private-active-active/README.md
+++ b/tests/private-active-active/README.md
@@ -7,7 +7,7 @@ following traits:
 
 - Active/Active mode
 - a medium VM machine type (m5.4xlarge)
-- Red Hat 7.8 as the VM image
+- Red Hat as the VM image
 - a privately accessible HTTP load balancer with TLS termination
 - a proxy server with TLS pass-through
 - Redis authentication

--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -1,6 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+data "aws_secretsmanager_secret" "vm_key" {
+  name = "wildcard-private-key-pem"
+}
+
+data "aws_secretsmanager_secret" "vm_certificate" {
+  name = "wildcard-chained-certificate-pem"
+}
+
 data "aws_ami" "rhel" {
   owners = ["309956199498"] # RedHat
 

--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -8,7 +8,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
+    values = ["RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2"]
   }
 
   filter {

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -50,6 +50,7 @@ module "private_active_active" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                        = data.aws_ami.rhel.id
+  bypass_preflight_checks       = true
   distribution                  = "rhel"
   consolidated_services_enabled = var.consolidated_services_enabled
   health_check_grace_period     = 3000

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -66,6 +66,8 @@ module "private_active_active" {
   redis_encryption_in_transit   = true
   redis_use_password_auth       = true
   tfe_subdomain                 = local.test_name
+  vm_certificate_secret_id      = data.aws_secretsmanager_secret.vm_certificate.id
+  vm_key_secret_id              = data.aws_secretsmanager_secret.vm_key.id
 
   asg_tags = local.common_tags
 

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -52,6 +52,7 @@ module "private_active_active" {
   ami_id                        = data.aws_ami.rhel.id
   distribution                  = "rhel"
   consolidated_services_enabled = var.consolidated_services_enabled
+  health_check_grace_period     = 3000
   iact_subnet_list              = ["0.0.0.0/0"]
   iam_role_policy_arns          = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type                 = "m5.4xlarge"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -19,7 +19,7 @@ resource "random_string" "friendly_name" {
 }
 
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = local.utility_module_test || !var.is_replicated_deployment ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {

--- a/tests/private-tcp-active-active/README.md
+++ b/tests/private-tcp-active-active/README.md
@@ -7,7 +7,7 @@ following traits:
 
 - Active/Active mode
 - a large VM machine type (m5.8xlarge)
-- Red Hat 7.8 as the VM image
+- Red Hat as the VM image
 - a privately accessible TCP load balancer with TLS pass-through
 - a proxy server with TLS termination
 - Redis authentication

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -16,7 +16,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
+    values = ["RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2"]
   }
 
   filter {

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -82,5 +82,5 @@ module "private_tcp_active_active" {
   registry_password         = var.registry_password
   registry_username         = var.registry_username
   tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
-  tls_ca_bundle_file        = "/usr/share/pki/ca-trust-source/anchors/tfe-ca-certificate.crt"
+  # tls_ca_bundle_file        = "/usr/share/pki/ca-trust-source/anchors/tfe-ca-certificate.crt"
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -19,7 +19,7 @@ resource "random_string" "friendly_name" {
 }
 
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = local.utility_module_test || !var.is_replicated_deployment ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -56,6 +56,7 @@ module "private_tcp_active_active" {
   ca_certificate_secret_id      = data.aws_secretsmanager_secret.ca_certificate.arn
   consolidated_services_enabled = var.consolidated_services_enabled
   distribution                  = "rhel"
+  health_check_grace_period     = 3000
   iact_subnet_list              = ["0.0.0.0/0"]
   iam_role_policy_arns          = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   instance_type                 = "m5.8xlarge"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -68,8 +68,6 @@ module "private_tcp_active_active" {
   redis_encryption_in_transit   = true
   redis_use_password_auth       = true
   tfe_subdomain                 = local.test_name
-  tls_bootstrap_cert_pathname   = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname    = "/var/lib/terraform-enterprise/key.pem"
   vm_certificate_secret_id      = var.certificate_pem_secret_id
   vm_key_secret_id              = var.private_key_pem_secret_id
 

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -53,6 +53,7 @@ module "private_tcp_active_active" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                        = data.aws_ami.rhel.id
+  bypass_preflight_checks       = true
   ca_certificate_secret_id      = data.aws_secretsmanager_secret.ca_certificate.arn
   consolidated_services_enabled = var.consolidated_services_enabled
   distribution                  = "rhel"
@@ -81,5 +82,4 @@ module "private_tcp_active_active" {
   registry_password         = var.registry_password
   registry_username         = var.registry_username
   tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
-  # tls_ca_bundle_file        = "/usr/share/pki/ca-trust-source/anchors/tfe-ca-certificate.crt"
 }

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -16,3 +16,11 @@ data "aws_ami" "ubuntu" {
 
   owners = ["099720109477"] # Canonical
 }
+
+data "aws_secretsmanager_secret" "vm_key" {
+  name = "wildcard-private-key-pem"
+}
+
+data "aws_secretsmanager_secret" "vm_certificate" {
+  name = "wildcard-chained-certificate-pem"
+}

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -44,7 +44,7 @@ module "public_active_active" {
 
   ami_id                        = data.aws_ami.ubuntu.id
   consolidated_services_enabled = var.consolidated_services_enabled
-  iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list              = var.iact_subnet_list
   instance_type                 = "m5.xlarge"
   key_name                      = var.key_name
@@ -55,6 +55,10 @@ module "public_active_active" {
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false
   tfe_subdomain                 = local.test_name
+  tls_bootstrap_cert_pathname   = "/etc/ssl/private/terraform-enterprise/cert.pem"
+  tls_bootstrap_key_pathname    = "/etc/ssl/private/terraform-enterprise/key.pem"
+  vm_certificate_secret_id      = data.aws_secretsmanager_secret.vm_certificate.id
+  vm_key_secret_id              = data.aws_secretsmanager_secret.vm_key.id
 
   asg_tags = local.common_tags
 

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -19,7 +19,7 @@ resource "random_string" "friendly_name" {
 }
 
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = local.utility_module_test || !var.is_replicated_deployment ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -43,6 +43,7 @@ module "public_active_active" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
   ami_id                        = data.aws_ami.ubuntu.id
+  bypass_preflight_checks       = true
   consolidated_services_enabled = var.consolidated_services_enabled
   health_check_grace_period     = 3000
   iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -44,6 +44,7 @@ module "public_active_active" {
 
   ami_id                        = data.aws_ami.ubuntu.id
   consolidated_services_enabled = var.consolidated_services_enabled
+  health_check_grace_period     = 3000
   iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list              = var.iact_subnet_list
   instance_type                 = "m5.xlarge"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -55,8 +55,6 @@ module "public_active_active" {
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false
   tfe_subdomain                 = local.test_name
-  tls_bootstrap_cert_pathname   = "/etc/ssl/private/terraform-enterprise/cert.pem"
-  tls_bootstrap_key_pathname    = "/etc/ssl/private/terraform-enterprise/key.pem"
   vm_certificate_secret_id      = data.aws_secretsmanager_secret.vm_certificate.id
   vm_key_secret_id              = data.aws_secretsmanager_secret.vm_key.id
 

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -47,7 +47,7 @@ module "public_active_active" {
   consolidated_services_enabled = var.consolidated_services_enabled
   health_check_grace_period     = 3000
   iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  iact_subnet_list              = var.iact_subnet_list
+  iact_subnet_list              = ["0.0.0.0/0"]
   instance_type                 = "m5.xlarge"
   key_name                      = var.key_name
   kms_key_arn                   = module.kms.key

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -28,12 +28,6 @@ variable "hc_license" {
   description = "(Not needed if is_replicated_deployment is true) The raw TFE license that is validated on application startup."
 }
 
-variable "iact_subnet_list" {
-  default     = []
-  description = "A list of CIDR masks that configure the ability to retrieve the IACT from outside the host."
-  type        = list(string)
-}
-
 variable "is_replicated_deployment" {
   type        = bool
   description = "TFE will be installed using a Replicated license and deployment method."

--- a/tests/standalone-vault/data.tf
+++ b/tests/standalone-vault/data.tf
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "aws_secretsmanager_secret" "vm_key" {
+  name = "wildcard-private-key-pem"
+}
+
+data "aws_secretsmanager_secret" "vm_certificate" {
+  name = "wildcard-chained-certificate-pem"
+}

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -50,6 +50,7 @@ module "standalone_vault" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   distribution          = "ubuntu"
 
+  bypass_preflight_checks       = true
   consolidated_services_enabled = var.consolidated_services_enabled
   health_check_grace_period     = 3000
   iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -51,6 +51,7 @@ module "standalone_vault" {
   distribution          = "ubuntu"
 
   consolidated_services_enabled = var.consolidated_services_enabled
+  health_check_grace_period     = 3000
   iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   iact_subnet_list              = ["0.0.0.0/0"]
   instance_type                 = "m5.xlarge"

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -13,7 +13,7 @@ resource "random_string" "friendly_name" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = local.utility_module_test || !var.is_replicated_deployment ? 0 : 1
   source = "../../fixtures/secrets"
 
   tfe_license = {

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -64,6 +64,8 @@ module "standalone_vault" {
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false
   tfe_subdomain                 = local.friendly_name_prefix
+  vm_certificate_secret_id      = data.aws_secretsmanager_secret.vm_certificate.id
+  vm_key_secret_id              = data.aws_secretsmanager_secret.vm_key.id
 
   # Vault
   extern_vault_enable    = true

--- a/tests/standalone-vault/outputs.tf
+++ b/tests/standalone-vault/outputs.tf
@@ -6,6 +6,11 @@ output "ptfe_endpoint" {
   description = "The URL to the TFE application."
 }
 
+output "tfe_url" {
+  value       = module.standalone_vault.tfe_url
+  description = "The URL to the TFE application."
+}
+
 output "replicated_console_url" {
   value       = "${module.standalone_vault.tfe_url}:8800"
   description = "Terraform Enterprise Console URL"

--- a/variables.tf
+++ b/variables.tf
@@ -274,13 +274,13 @@ variable "tfe_license_file_location" {
 }
 
 variable "tls_bootstrap_cert_pathname" {
-  default     = "/etc/ssl/private/terraform-enterprise/cert.pem"
+  default     = "/etc/tfe/ssl/cert.pem"
   type        = string
   description = "The path on the TFE instance to put the certificate. ex. '/var/lib/terraform-enterprise/certificate.pem'"
 }
 
 variable "tls_bootstrap_key_pathname" {
-  default     = "/etc/ssl/private/terraform-enterprise/key.pem"
+  default     = "/etc/tfe/ssl/key.pem"
   type        = string
   description = "The path on the TFE instance to put the key. ex. '/var/lib/terraform-enterprise/key.pem'"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -274,13 +274,13 @@ variable "tfe_license_file_location" {
 }
 
 variable "tls_bootstrap_cert_pathname" {
-  default     = null
+  default     = "/etc/ssl/private/terraform-enterprise/cert.pem"
   type        = string
   description = "The path on the TFE instance to put the certificate. ex. '/var/lib/terraform-enterprise/certificate.pem'"
 }
 
 variable "tls_bootstrap_key_pathname" {
-  default     = null
+  default     = "/etc/ssl/private/terraform-enterprise/key.pem"
   type        = string
   description = "The path on the TFE instance to put the key. ex. '/var/lib/terraform-enterprise/key.pem'"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -274,13 +274,13 @@ variable "tfe_license_file_location" {
 }
 
 variable "tls_bootstrap_cert_pathname" {
-  default     = "/etc/tfe/ssl/cert.pem"
+  default     = "/var/lib/terraform-enterprise/certificate.pem"
   type        = string
   description = "The path on the TFE instance to put the certificate. ex. '/var/lib/terraform-enterprise/certificate.pem'"
 }
 
 variable "tls_bootstrap_key_pathname" {
-  default     = "/etc/tfe/ssl/key.pem"
+  default     = "/var/lib/terraform-enterprise/key.pem"
   type        = string
   description = "The path on the TFE instance to put the key. ex. '/var/lib/terraform-enterprise/key.pem'"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -459,14 +459,15 @@ variable "tls_ciphers" {
 }
 
 variable "tls_version" {
-  default     = null
+  default     = "tls_1_2_tls_1_3"
   type        = string
   description = "(Not needed if is_replicated_deployment is true) TLS version to use. Leave blank to use both TLS v1.2 and TLS v1.3. Defaults to '' if no value is given."
   validation {
     condition = (
       var.tls_version == null ||
       var.tls_version == "tls_1_2" ||
-      var.tls_version == "tls_1_3"
+      var.tls_version == "tls_1_3" ||
+      var.tls_version == "tls_1_2_tls_1_3"
     )
     error_message = "The tls_version value must be 'tls_1_2', 'tls_1_3', or null."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -226,6 +226,18 @@ variable "hairpin_addressing" {
   description = "In some cloud environments, HTTP clients running on instances behind a loadbalancer cannot send requests to the public hostname of that load balancer. Use this setting to configure TFE services to redirect requests for the installation's FQDN to the instance's internal IP address. Defaults to false."
 }
 
+variable "http_port" {
+  default     = 8080
+  type        = number
+  description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTP. Default is 80."
+}
+
+variable "https_port" {
+  default     = 8443
+  type        = number
+  description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTPS. Default is 443."
+}
+
 variable "iact_subnet_list" {
   default     = []
   description = "A list of CIDR masks that configure the ability to retrieve the IACT from outside the host."

--- a/variables.tf
+++ b/variables.tf
@@ -369,6 +369,12 @@ variable "existing_iam_instance_role_name" {
   type        = string
 }
 
+variable "health_check_grace_period" {
+  default     = null
+  description = "The health grace period aws provides to allow for an instance to pass it's health check."
+  type        = number
+}
+
 variable "iam_role_policy_arns" {
   default     = []
   description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."

--- a/variables.tf
+++ b/variables.tf
@@ -452,12 +452,6 @@ variable "ssl_policy" {
   description = "SSL policy to use on ALB listener"
 }
 
-variable "tls_ca_bundle_file" {
-  default     = null
-  type        = string
-  description = "(Not needed if is_replicated_deployment is true) Path to a file containing TLS CA certificates to be added to the OS CA certificates bundle. Leave blank to not add CA certificates to the OS CA certificates bundle. Defaults to ''."
-}
-
 variable "tls_ciphers" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

[TF-8609](https://hashicorp.atlassian.net/browse/TF-8609)

This branch uses the changes that were made in the [terraform-utility-tfe-random](https://github.com/hashicorp/terraform-random-tfe-utility/pull/129) repo to install a Docker deployment of FDO ([Jira TF-5370](https://hashicorp.atlassian.net/browse/TF-5370)).

After all of the changes, the Azure TFE module had to be updated, as well, therefore, those changes are [here](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/236).

## TO DO

- [ ] Merge [Utility TFE PR](https://github.com/hashicorp/terraform-random-tfe-utility/pull/129)
- [ ] Merge [Azure TFE PR](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/236)
- [x] Change the modules' git refs back to `main`
    - [x] In test workflow
    - [x] In `main.tf`
- [x] ptfe-replicated azurerm tests pass ([url](https://github.com/hashicorp/ptfe-replicated/actions/runs/6708972051/job/18233666139#step:15:1591))
- [x] ptfe-replicated aws tests pass ([url](https://github.com/hashicorp/ptfe-replicated/actions/runs/6709018901/job/18241022891#step:15:3156))


## How Has This Been Tested

Below are the passing tests. You should see 10 passing tests in this PR's comments.
## This PR makes me feel

![whack-a-mole](https://media.giphy.com/media/ebITvSXYKNvRm/giphy.gif)


[TF-8609]: https://hashicorp.atlassian.net/browse/TF-8609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ