### PR TITLE
revert secretsmanager policy count

### DIFF
--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_iam_role_policy" "secretsmanager" {
-  count = var.existing_iam_instance_profile_name == null && !var.enable_airgap && local.secret_arns != [] ? 1 : 0
+  count = var.existing_iam_instance_profile_name == null && !var.enable_airgap ? 1 : 0
 
   policy = data.aws_iam_policy_document.secretsmanager[0].json
   role   = local.iam_instance_role.id


### PR DESCRIPTION
## Background

I had added this change for FDO, but it broke Replicated, so I need to revert it while we do release testing and fix it when I'm back to working on FDO again.

I tested it in [this CI run in ptfe-replicated](https://github.com/hashicorp/ptfe-replicated/actions/runs/6317484858/job/17154425599).
