### PR TITLE
replace consolidated_services with consolidated_services_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -210,20 +210,20 @@ module "settings" {
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE Base Configuration
-  consolidated_services       = var.consolidated_services
-  custom_image_tag            = var.custom_image_tag
-  custom_agent_image_tag      = var.custom_agent_image_tag
-  hairpin_addressing          = var.hairpin_addressing
-  production_type             = var.operational_mode
-  disk_path                   = local.enable_disk ? var.disk_path : null
-  iact_subnet_list            = var.iact_subnet_list
-  iact_subnet_time_limit      = var.iact_subnet_time_limit
-  metrics_endpoint_enabled    = var.metrics_endpoint_enabled
-  metrics_endpoint_port_http  = var.metrics_endpoint_port_http
-  metrics_endpoint_port_https = var.metrics_endpoint_port_https
-  trusted_proxies             = var.trusted_proxies
-  release_sequence            = var.release_sequence
-  pg_extra_params             = var.pg_extra_params
+  consolidated_services_enabled = var.consolidated_services_enabled
+  custom_image_tag              = var.custom_image_tag
+  custom_agent_image_tag        = var.custom_agent_image_tag
+  hairpin_addressing            = var.hairpin_addressing
+  production_type               = var.operational_mode
+  disk_path                     = local.enable_disk ? var.disk_path : null
+  iact_subnet_list              = var.iact_subnet_list
+  iact_subnet_time_limit        = var.iact_subnet_time_limit
+  metrics_endpoint_enabled      = var.metrics_endpoint_enabled
+  metrics_endpoint_port_http    = var.metrics_endpoint_port_http
+  metrics_endpoint_port_https   = var.metrics_endpoint_port_https
+  trusted_proxies               = var.trusted_proxies
+  release_sequence              = var.release_sequence
+  pg_extra_params               = var.pg_extra_params
 
   extra_no_proxy = concat([
     "127.0.0.1",

--- a/tests/active-active-rhel7-proxy/main.tf
+++ b/tests/active-active-rhel7-proxy/main.tf
@@ -79,23 +79,23 @@ module "tfe" {
   friendly_name_prefix  = local.friendly_name_prefix
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
-  ami_id                   = data.aws_ami.rhel.id
-  aws_access_key_id        = var.aws_access_key_id
-  aws_secret_access_key    = var.aws_secret_access_key
-  ca_certificate_secret_id = data.aws_secretsmanager_secret.ca_certificate.arn
-  consolidated_services    = var.consolidated_services
-  distribution             = "rhel"
-  iact_subnet_list         = ["0.0.0.0/0"]
-  iam_role_policy_arns     = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  instance_type            = "m5.xlarge"
-  key_name                 = local.utility_module_test ? var.key_name : aws_key_pair.main[0].key_name
-  kms_key_arn              = module.kms.key
-  load_balancing_scheme    = local.load_balancing_scheme
-  object_storage_iam_user  = data.aws_iam_user.object_storage
-  node_count               = 2
-  proxy_ip                 = module.test_proxy.proxy_ip
-  proxy_port               = local.http_proxy_port
-  tfe_subdomain            = local.test_name
+  ami_id                        = data.aws_ami.rhel.id
+  aws_access_key_id             = var.aws_access_key_id
+  aws_secret_access_key         = var.aws_secret_access_key
+  ca_certificate_secret_id      = data.aws_secretsmanager_secret.ca_certificate.arn
+  consolidated_services_enabled = var.consolidated_services_enabled
+  distribution                  = "rhel"
+  iact_subnet_list              = ["0.0.0.0/0"]
+  iam_role_policy_arns          = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  instance_type                 = "m5.xlarge"
+  key_name                      = local.utility_module_test ? var.key_name : aws_key_pair.main[0].key_name
+  kms_key_arn                   = module.kms.key
+  load_balancing_scheme         = local.load_balancing_scheme
+  object_storage_iam_user       = data.aws_iam_user.object_storage
+  node_count                    = 2
+  proxy_ip                      = module.test_proxy.proxy_ip
+  proxy_port                    = local.http_proxy_port
+  tfe_subdomain                 = local.test_name
 
   asg_tags = local.common_tags
 

--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -31,7 +31,7 @@ variable "ca_private_key_secret_name" {
   description = "The secrets manager secret name of the Base64 encoded CA private key."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -49,22 +49,22 @@ module "private_active_active" {
   friendly_name_prefix  = local.friendly_name_prefix
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
-  ami_id                      = data.aws_ami.rhel.id
-  distribution                = "rhel"
-  consolidated_services       = var.consolidated_services
-  iact_subnet_list            = ["0.0.0.0/0"]
-  iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  instance_type               = "m5.4xlarge"
-  key_name                    = var.key_name
-  kms_key_arn                 = module.kms.key
-  load_balancing_scheme       = local.load_balancing_scheme
-  node_count                  = 2
-  proxy_ip                    = module.test_proxy.proxy_ip
-  proxy_port                  = local.http_proxy_port
-  redis_encryption_at_rest    = false
-  redis_encryption_in_transit = true
-  redis_use_password_auth     = true
-  tfe_subdomain               = local.test_name
+  ami_id                        = data.aws_ami.rhel.id
+  distribution                  = "rhel"
+  consolidated_services_enabled = var.consolidated_services_enabled
+  iact_subnet_list              = ["0.0.0.0/0"]
+  iam_role_policy_arns          = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  instance_type                 = "m5.4xlarge"
+  key_name                      = var.key_name
+  kms_key_arn                   = module.kms.key
+  load_balancing_scheme         = local.load_balancing_scheme
+  node_count                    = 2
+  proxy_ip                      = module.test_proxy.proxy_ip
+  proxy_port                    = local.http_proxy_port
+  redis_encryption_at_rest      = false
+  redis_encryption_in_transit   = true
+  redis_use_password_auth       = true
+  tfe_subdomain                 = local.test_name
 
   asg_tags = local.common_tags
 

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -11,7 +11,7 @@ variable "aws_role_arn" {
   description = "The AWS Role ARN to assume for this module."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -52,26 +52,26 @@ module "private_tcp_active_active" {
   friendly_name_prefix  = local.friendly_name_prefix
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
-  ami_id                      = data.aws_ami.rhel.id
-  ca_certificate_secret_id    = data.aws_secretsmanager_secret.ca_certificate.arn
-  consolidated_services       = var.consolidated_services
-  distribution                = "rhel"
-  iact_subnet_list            = ["0.0.0.0/0"]
-  iam_role_policy_arns        = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  instance_type               = "m5.8xlarge"
-  kms_key_arn                 = module.kms.key
-  load_balancing_scheme       = local.load_balancing_scheme
-  node_count                  = 2
-  proxy_ip                    = module.test_proxy.proxy_ip
-  proxy_port                  = local.http_proxy_port
-  redis_encryption_at_rest    = true
-  redis_encryption_in_transit = true
-  redis_use_password_auth     = true
-  tfe_subdomain               = local.test_name
-  tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"
-  tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
-  vm_certificate_secret_id    = var.certificate_pem_secret_id
-  vm_key_secret_id            = var.private_key_pem_secret_id
+  ami_id                        = data.aws_ami.rhel.id
+  ca_certificate_secret_id      = data.aws_secretsmanager_secret.ca_certificate.arn
+  consolidated_services_enabled = var.consolidated_services_enabled
+  distribution                  = "rhel"
+  iact_subnet_list              = ["0.0.0.0/0"]
+  iam_role_policy_arns          = [local.ssm_policy_arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  instance_type                 = "m5.8xlarge"
+  kms_key_arn                   = module.kms.key
+  load_balancing_scheme         = local.load_balancing_scheme
+  node_count                    = 2
+  proxy_ip                      = module.test_proxy.proxy_ip
+  proxy_port                    = local.http_proxy_port
+  redis_encryption_at_rest      = true
+  redis_encryption_in_transit   = true
+  redis_use_password_auth       = true
+  tfe_subdomain                 = local.test_name
+  tls_bootstrap_cert_pathname   = "/var/lib/terraform-enterprise/certificate.pem"
+  tls_bootstrap_key_pathname    = "/var/lib/terraform-enterprise/key.pem"
+  vm_certificate_secret_id      = var.certificate_pem_secret_id
+  vm_key_secret_id              = var.private_key_pem_secret_id
 
   asg_tags = local.common_tags
 

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -26,7 +26,7 @@ variable "certificate_pem_secret_id" {
   description = "The secrets manager secret ID of the Base64 & PEM encoded TLS certificate."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -42,19 +42,19 @@ module "public_active_active" {
   distribution          = "ubuntu"
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
 
-  ami_id                      = data.aws_ami.ubuntu.id
-  consolidated_services       = var.consolidated_services
-  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  iact_subnet_list            = var.iact_subnet_list
-  instance_type               = "m5.xlarge"
-  key_name                    = var.key_name
-  kms_key_arn                 = module.kms.key
-  load_balancing_scheme       = local.load_balancing_scheme
-  node_count                  = 2
-  redis_encryption_at_rest    = false
-  redis_encryption_in_transit = false
-  redis_use_password_auth     = false
-  tfe_subdomain               = local.test_name
+  ami_id                        = data.aws_ami.ubuntu.id
+  consolidated_services_enabled = var.consolidated_services_enabled
+  iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  iact_subnet_list              = var.iact_subnet_list
+  instance_type                 = "m5.xlarge"
+  key_name                      = var.key_name
+  kms_key_arn                   = module.kms.key
+  load_balancing_scheme         = local.load_balancing_scheme
+  node_count                    = 2
+  redis_encryption_at_rest      = false
+  redis_encryption_in_transit   = false
+  redis_use_password_auth       = false
+  tfe_subdomain                 = local.test_name
 
   asg_tags = local.common_tags
 

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -11,7 +11,7 @@ variable "aws_role_arn" {
   description = "The AWS Role ARN to assume for this module."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -50,18 +50,18 @@ module "standalone_vault" {
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   distribution          = "ubuntu"
 
-  consolidated_services       = var.consolidated_services
-  iam_role_policy_arns        = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  iact_subnet_list            = ["0.0.0.0/0"]
-  instance_type               = "m5.xlarge"
-  key_name                    = local.utility_module_test ? var.key_name : "standalone-vault"
-  kms_key_arn                 = module.kms.key
-  load_balancing_scheme       = local.load_balancing_scheme
-  node_count                  = 1
-  redis_encryption_at_rest    = false
-  redis_encryption_in_transit = false
-  redis_use_password_auth     = false
-  tfe_subdomain               = local.friendly_name_prefix
+  consolidated_services_enabled = var.consolidated_services_enabled
+  iam_role_policy_arns          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  iact_subnet_list              = ["0.0.0.0/0"]
+  instance_type                 = "m5.xlarge"
+  key_name                      = local.utility_module_test ? var.key_name : "standalone-vault"
+  kms_key_arn                   = module.kms.key
+  load_balancing_scheme         = local.load_balancing_scheme
+  node_count                    = 1
+  redis_encryption_at_rest      = false
+  redis_encryption_in_transit   = false
+  redis_use_password_auth       = false
+  tfe_subdomain                 = local.friendly_name_prefix
 
   # Vault
   extern_vault_enable    = true

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -11,7 +11,7 @@ variable "aws_role_arn" {
   description = "The AWS Role ARN to assume for this module."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/variables.tf
+++ b/variables.tf
@@ -196,7 +196,7 @@ variable "capacity_memory" {
   description = "The maximum amount of memory (in megabytes) that a Terraform plan or apply can use on the system; defaults to `512` for replicated mode and `2048` for FDO."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."


### PR DESCRIPTION
## Background

This updates the module to use the `consolidated_services_enabled` variable since it was changed in [this merge](https://github.com/hashicorp/ptfe-replicated/pull/1734) to `ptfe-replicated`.

## How Has This Been Tested

Since tests are not working in this repo, I will test in `ptfe-replicated` post merge.