### PR TITLE
default consolidated_services_enabled to true

### DIFF
--- a/tests/active-active-rhel7-proxy/variables.tf
+++ b/tests/active-active-rhel7-proxy/variables.tf
@@ -32,7 +32,7 @@ variable "ca_private_key_secret_name" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -12,7 +12,7 @@ variable "aws_role_arn" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -27,7 +27,7 @@ variable "certificate_pem_secret_id" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -12,7 +12,7 @@ variable "aws_role_arn" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/standalone-vault/variables.tf
+++ b/tests/standalone-vault/variables.tf
@@ -12,7 +12,7 @@ variable "aws_role_arn" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "capacity_memory" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }


### PR DESCRIPTION
## Background
#306 
This is a followup PR so that the `consolidated_services_enabled` variable is defaulted to `true`. 