### PR TITLE
add aws access creds to tcp test

### DIFF
--- a/.github/workflows/handler-help.yml
+++ b/.github/workflows/handler-help.yml
@@ -41,4 +41,4 @@ jobs:
             * public-active-active-replicated
             * standalone-vault-replicated
 
-          reaction-type: confused
+          reactions: confused

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -196,6 +196,9 @@ jobs:
       work_dir: ./tests/private-tcp-active-active
       TFC_token_secret_name: PRIVATE_TCP_ACTIVE_ACTIVE_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/aws-private-tcp-active-active/aws-private-tcp-active-active-replicated/
+      aws_access_key_id: PRIVATE_TCP_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID
+      aws_secret_access_key: PRIVATE_TCP_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY
+      aws_role_to_assume: PRIVATE_TCP_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME
 
   standalone_vault_replicated:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -177,6 +177,9 @@ jobs:
       work_dir: ./tests/private-active-active
       TFC_token_secret_name: PRIVATE_ACTIVE_ACTIVE_REPLICATED_TFC_TOKEN
       TFC_workspace_substitution_pattern: s/aws-private-active-active/aws-private-active-active-replicated/
+      aws_access_key_id: PRIVATE_ACTIVE_ACTIVE_AWS_ACCESS_KEY_ID
+      aws_secret_access_key: PRIVATE_ACTIVE_ACTIVE_AWS_SECRET_ACCESS_KEY
+      aws_role_to_assume: PRIVATE_ACTIVE_ACTIVE_AWS_ROLE_TO_ASSUME
 
   private_tcp_active_active_replicated:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/aws-tests.yml@ah/tf-8609-fdo-6


### PR DESCRIPTION
## Background

[TF-8609](https://hashicorp.atlassian.net/browse/TF-8609)

Just chipping away at the workflows to get them to work properly. This adds in the creds for the tcp test to be able to log into AWS.

## How Has This Been Tested

Will be tested post-merge. In this other test, the test with the creds [passed](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6475571400/job/17582795230#step:18:17) the credentials step, and the one without the creds [failed](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6475571400/job/17582796274#step:18:13) that step.

[TF-8609]: https://hashicorp.atlassian.net/browse/TF-8609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ