### PR TITLE
[TF-10415] associate public ips with instances from asg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ data "aws_kms_key" "main" {
 }
 
 # -----------------------------------------------------------------------------
-# AWS Service Accounts 
+# AWS Service Accounts
 # -----------------------------------------------------------------------------
 module "service_accounts" {
   source = "./modules/service_accounts"
@@ -340,6 +340,7 @@ module "vm" {
   default_ami_id                      = local.default_ami_id
   enable_disk                         = local.enable_disk
   enable_ssh                          = var.enable_ssh
+  enable_public_ip                    = var.enable_public_ip
   ebs_device_name                     = var.ebs_device_name
   ebs_volume_size                     = var.ebs_volume_size
   ebs_volume_type                     = var.ebs_volume_type

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -78,9 +78,10 @@ resource "aws_launch_configuration" "tfe" {
   instance_type    = var.instance_type
   user_data_base64 = var.user_data_base64
 
-  iam_instance_profile = var.aws_iam_instance_profile
-  key_name             = var.key_name
-  security_groups      = [aws_security_group.tfe_instance.id]
+  iam_instance_profile        = var.aws_iam_instance_profile
+  key_name                    = var.key_name
+  security_groups             = [aws_security_group.tfe_instance.id]
+  associate_public_ip_address = var.enable_public_ip
 
   metadata_options {
     http_endpoint = "enabled"

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -46,6 +46,11 @@ variable "enable_ssh" {
   description = "Whether to open port 22 on the TFE instance for SSH access."
 }
 
+variable "enable_public_ip" {
+  type        = bool
+  description = "Whether public IPs should be attached to the EC2 instance(s)."
+}
+
 variable "friendly_name_prefix" {
   type        = string
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."

--- a/variables.tf
+++ b/variables.tf
@@ -317,6 +317,12 @@ variable "enable_ssh" {
   default     = false
 }
 
+variable "enable_public_ip" {
+  type        = bool
+  description = "Whether public IPs should be attached to the EC2 instance(s)."
+  default     = false
+}
+
 variable "hc_license" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

This PR adds an input to the Terraform module to associate public IPs to the EC2 instances created by the ASG, if the user so desires. 
