### PR TITLE
add to no_proxy list

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -56,6 +56,7 @@ locals {
     "169.254.169.254",
     "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
     ".docker.com",
+    ".docker.io",
     "localhost",
     "s3.amazonaws.com",
     ".s3.amazonaws.com",

--- a/locals.tf
+++ b/locals.tf
@@ -56,15 +56,27 @@ locals {
     "169.254.169.254",
     ".aws.ce.redhat.com",
     "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
-    "download.docker.com",
+    ".docker.com",
     "centos.org",
     "localhost",
     "s3.amazonaws.com",
     ".s3.amazonaws.com",
     "s3.${data.aws_region.current.name}.amazonaws.com",
     local.fqdn,
-    var.network_cidr
-  ], var.no_proxy)
+    var.network_cidr],
+    local.replicated_no_proxy,
+    local.rhel_no_proxy,
+    var.no_proxy
+  )
+
+  replicated_no_proxy = var.is_replicated_deployment ? [
+    "registry.replicated.com"
+  ] : []
+
+  rhel_no_proxy = var.distribution == "rhel" ? [
+    ".subscription.rhn.redhat.com",
+    ".cdn.redhat.com",
+  ] : []
 
   trusted_proxies = concat(
     var.trusted_proxies,

--- a/locals.tf
+++ b/locals.tf
@@ -54,10 +54,8 @@ locals {
   no_proxy = concat([
     "127.0.0.1",
     "169.254.169.254",
-    ".aws.ce.redhat.com",
     "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
     ".docker.com",
-    "centos.org",
     "localhost",
     "s3.amazonaws.com",
     ".s3.amazonaws.com",
@@ -70,10 +68,12 @@ locals {
   )
 
   replicated_no_proxy = var.is_replicated_deployment ? [
-    "registry.replicated.com"
+    ".replicated.com",
   ] : []
 
   rhel_no_proxy = var.distribution == "rhel" ? [
+    ".aws.ce.redhat.com",
+    ".centos.org",
     ".subscription.rhn.redhat.com",
     ".cdn.redhat.com",
   ] : []

--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ module "docker_compose_config" {
   https_port                = var.https_port
   http_proxy                = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null
   https_proxy               = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null
-  no_proxy                  = local.no_proxy
+  no_proxy                  = var.proxy_ip != null ? local.no_proxy : null
   license_reporting_opt_out = var.license_reporting_opt_out
   operational_mode          = local.fdo_operational_mode
 
@@ -197,9 +197,9 @@ module "tfe_init_fdo" {
   certificate_secret_id    = var.vm_certificate_secret_id == null ? null : var.vm_certificate_secret_id
   key_secret_id            = var.vm_key_secret_id == null ? null : var.vm_key_secret_id
 
-  proxy_ip       = var.proxy_ip
-  proxy_port     = var.proxy_port
-  extra_no_proxy = local.no_proxy
+  proxy_ip       = var.proxy_ip != null ? var.proxy_ip : null
+  proxy_port     = var.proxy_ip != null ? var.proxy_port : null
+  extra_no_proxy = var.proxy_ip != null ? local.no_proxy : null
 
   registry_username   = var.registry_username
   registry_password   = var.registry_password


### PR DESCRIPTION
## Background

[TF-8609](https://hashicorp.atlassian.net/browse/TF-8609)

After the initial passing tests from the FDO addition, we have seen some more failures intermittently. This PR seeks to clear up those failures by fixing the `no_proxy` logic.

## How Has This Been Tested

Here are the links to each of the passing tests, also shown below.

- [x] [active-active-rhel7-proxy](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882341519/job/18720652756)
- [x] [private-active-active](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882029160/job/18719662689)
- [x] [private-tcp-active-active](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882501824/job/18721134284)
- [x] [public-active-active](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882509148/job/18721157993)
- [x] [standalone-vault](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882441188/job/18720948469)
- [x] [active-active-rhel7-proxy-replicated](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6883689544/job/18724733064)
- [x] [private-active-active-replicated](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882030464/job/18719666102)
- [x] [private-tcp-active-active-replicated](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6883149367/job/18723522431)
- [x] [public-active-active-replicated](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882433536/job/18720924851)
- [x] [standalone-vault-replicated](https://github.com/hashicorp/terraform-aws-terraform-enterprise/actions/runs/6882401211/job/18720833277)

[TF-8609]: https://hashicorp.atlassian.net/browse/TF-8609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ