### PR TITLE
add disk_path to docker_compose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ module "docker_compose_config" {
 
   tfe_license = var.hc_license
 
-  hostname                  = local.fqdn
+  disk_path                 = var.operational_mode == "disk" ? var.disk_path : null  hostname                  = local.fqdn
   http_port                 = var.http_port
   https_port                = var.https_port
   http_proxy                = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ module "database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/disk_path"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license
@@ -181,7 +181,7 @@ module "docker_compose_config" {
 # AWS cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # --------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/disk_path"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "aws"

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ module "database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/disk_path"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license
@@ -181,7 +181,7 @@ module "docker_compose_config" {
 # AWS cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # --------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/disk_path"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "aws"

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,8 @@ module "docker_compose_config" {
 
   tfe_license = var.hc_license
 
-  disk_path                 = var.operational_mode == "disk" ? var.disk_path : null  hostname                  = local.fqdn
+  disk_path                 = var.operational_mode == "disk" ? var.disk_path : null
+  hostname                  = local.fqdn
   http_port                 = var.http_port
   https_port                = var.https_port
   http_proxy                = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -45,6 +45,7 @@ module "standalone_vault" {
   source = "../../"
 
   acm_certificate_arn   = var.acm_certificate_arn
+  disk_path             = "/opt/hashicorp/data"
   domain_name           = var.domain_name
   friendly_name_prefix  = local.friendly_name_prefix
   tfe_license_secret_id = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
@@ -60,6 +61,7 @@ module "standalone_vault" {
   kms_key_arn                   = module.kms.key
   load_balancing_scheme         = local.load_balancing_scheme
   node_count                    = 1
+  operational_mode              = "'disk"
   redis_encryption_at_rest      = false
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false

--- a/tests/standalone-vault/main.tf
+++ b/tests/standalone-vault/main.tf
@@ -61,7 +61,7 @@ module "standalone_vault" {
   kms_key_arn                   = module.kms.key
   load_balancing_scheme         = local.load_balancing_scheme
   node_count                    = 1
-  operational_mode              = "'disk"
+  operational_mode              = "disk"
   redis_encryption_at_rest      = false
   redis_encryption_in_transit   = false
   redis_use_password_auth       = false

--- a/variables.tf
+++ b/variables.tf
@@ -225,7 +225,7 @@ variable "custom_image_tag" {
 
 variable "disk_path" {
   default     = null
-  description = "The pathname of the directory in which Terraform Enterprise will store data on the compute instances."
+  description = "The pathname of the directory in which Terraform Enterprise will store data on the compute instances. Required if var.is_replicated_deployment is false and var.operational_mode is 'disk'."
   type        = string
 }
 


### PR DESCRIPTION
## Background

Relates: https://github.com/hashicorp/terraform-random-tfe-utility/pull/135

While testing a backup, @miguelhrocha discovered that the disk_path was not set for FDO deployments. It had gone unnoticed since we had not done a backup test yet using these modules as it was using the default docker mount.

## How Has This Been Tested

Passing tests below. Also, here you can see that the postgres data is on the instance.

<img width="439" alt="Screenshot 2023-11-15 at 10 12 12 AM" src="https://github.com/hashicorp/terraform-aws-terraform-enterprise/assets/18335499/d944cece-df12-45dc-8999-341bdf74cbca">


