### PR TITLE
feat: configurable health_check_type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -358,6 +358,7 @@ module "vm" {
   ebs_snapshot_id                        = var.ebs_snapshot_id
   friendly_name_prefix                   = var.friendly_name_prefix
   health_check_grace_period              = var.health_check_grace_period
+  health_check_type                      = var.health_check_type
   instance_type                          = var.instance_type
   is_replicated_deployment               = var.is_replicated_deployment
   key_name                               = var.key_name

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -142,7 +142,7 @@ resource "aws_autoscaling_group" "tfe_asg" {
   # Increases grace period for any AMI that is not the default Ubuntu
   # since RHEL has longer startup time
   health_check_grace_period = local.health_check_grace_period
-  health_check_type         = "ELB"
+  health_check_type         = var.health_check_type
 
   launch_template {
     id      = aws_launch_template.tfe.id

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -56,6 +56,18 @@ variable "health_check_grace_period" {
   type        = number
 }
 
+variable "health_check_type" {
+  description = "Type of health check to perform on the instance."
+  type        = string
+  default     = "ELB"
+
+  validation {
+    condition     = contains(["ELB", "EC2"], var.health_check_type)
+    error_message = "Must be one of [ELB, EC2]."
+  }
+}
+
+
 variable "instance_type" {
   description = "The instance type of TFE EC2 instance(s) to create."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -406,6 +406,17 @@ variable "health_check_grace_period" {
   type        = number
 }
 
+variable "health_check_type" {
+  description = "Type of health check to perform on the instance."
+  type        = string
+  default     = "ELB"
+
+  validation {
+    condition     = contains(["ELB", "EC2"], var.health_check_type)
+    error_message = "Must be one of [ELB, EC2]."
+  }
+}
+
 variable "iam_role_policy_arns" {
   default     = []
   description = "A set of Amazon Resource Names of IAM role policies to be attached to the TFE IAM role."


### PR DESCRIPTION
## Background

This patch adds support for configuring the `health_check_type` of the underlying instance managed by the auto scaling group. This allows operators to switch from the comprehensive `ELB` check to a simpler `EC2` check to prevent the instance from being recycled during upgrades.

Resolves #273

## How Has This Been Tested

- `terraform init`
- CI/CD

### Test Configuration

- Terraform v1.7.5

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGd2MWd2OWNpYnYyZXFydTU0b2xtbWg4Z3N4cXdkOHU5eTVscnU4dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/StoeNoDkYuum8cj8MV/giphy.gif)
