### PR TITLE
Chore: Update deprecated default M4 type to M5

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -179,7 +179,7 @@ variable "db_parameters" {
 
 variable "db_size" {
   type        = string
-  default     = "db.m4.xlarge"
+  default     = "db.m5.xlarge"
   description = "PostgreSQL instance size."
 }
 


### PR DESCRIPTION
## Background
On the 29th of March, AWS has disabled new creation of M4 type instances of RDS. Instead, the recommendation to use M5 type instances. 
https://repost.aws/articles/AR_Rw2Xbe5Q9O1ZPKbU5S4Mg/amazon-rds-for-sql-server-is-ending-support-for-m4-r4-and-t2-database-instances-on-march-29-2024

In this PR we update the db size default value. 

## How has this been tested
I did not test it directly, but instead, verified that there are no orderable options for "db.m4.xlarge" 

```
aws rds describe-orderable-db-instance-options \
    --region "us-west-2" \
    --db-instance-class "db.m4.xlarge" \
    --engine postgres
```

and that on the other hand, there are plenty options with "db.m5.xlarge", including the current default version 12.15. 

```
aws rds describe-orderable-db-instance-options \
    --region "us-west-2" \
    --db-instance-class "db.m5.xlarge" \
    --engine postgres
```