### PR TITLE
Support Amazon Linux 2023

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -55,8 +55,8 @@ variable "distribution" {
   type        = string
   description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
   validation {
-    condition     = contains(["rhel", "ubuntu"], var.distribution)
-    error_message = "Supported values for distribution are 'rhel' or 'ubuntu'."
+    condition     = contains(["rhel", "ubuntu", "amazon-linux-2023"], var.distribution)
+    error_message = "Supported values for distribution are 'rhel', 'ubuntu' or amazon-linux-2023."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "distribution" {
   description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
   validation {
     condition     = contains(["rhel", "ubuntu", "amazon-linux-2023"], var.distribution)
-    error_message = "Supported values for distribution are 'rhel', 'ubuntu' or amazon-linux-2023."
+    error_message = "Supported values for distribution are 'rhel', 'ubuntu' or 'amazon-linux-2023'."
   }
 }
 


### PR DESCRIPTION
## Background

[Jira](https://hashicorp.atlassian.net/browse/TF-14068)

This PR supports allowing Amazon Linux 2023 setup on Replicated.

Depends on https://github.com/hashicorp/terraform-random-tfe-utility/pull/151

## How Has This Been Tested

See comment on jira ticket.

