### PR TITLE
Repairing the rhel 7.9 image ami query

### DIFF
--- a/tests/active-active-rhel7-proxy/data.tf
+++ b/tests/active-active-rhel7-proxy/data.tf
@@ -24,7 +24,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2"]
+    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
   }
 
   filter {


### PR DESCRIPTION
## Background

TF-14554 tests are failing in aws because the rhel 7.9 ami query is no longer valid.  This change should repair that query.


## How Has This Been Tested

This test will be vetted once merged.  Any corrections will come in the form of additional changes.

