### PR TITLE
Add vault_token_renew configuration to FDO settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,11 +173,12 @@ module "runtime_container_engine_config" {
 
   trusted_proxies = local.trusted_proxies
 
-  vault_address   = var.extern_vault_addr
-  vault_namespace = var.extern_vault_namespace
-  vault_path      = var.extern_vault_path
-  vault_role_id   = var.extern_vault_role_id
-  vault_secret_id = var.extern_vault_secret_id
+  vault_address     = var.extern_vault_addr
+  vault_namespace   = var.extern_vault_namespace
+  vault_path        = var.extern_vault_path
+  vault_role_id     = var.extern_vault_role_id
+  vault_secret_id   = var.extern_vault_secret_id
+  vault_token_renew = var.extern_vault_token_renew
 }
 
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Background

This PR propagates the `ext_vault_token_renew` setting to FDO deployments. Needed when using external Vault configurations.
