### PR TITLE
[TF-15186] add active-active as valid operational mode input

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
-  active_active                = var.node_count >= 2
+  active_active                = var.node_count >= 2 || var.operational_mode == "active-active"
   kms_key_arn                  = data.aws_kms_key.main.arn
   enable_airgap                = var.airgap_url == null && var.tfe_license_bootstrap_airgap_package_path != null
   enable_external              = var.operational_mode == "external" || local.active_active
@@ -10,7 +10,7 @@ locals {
   enable_database_module       = local.enable_external
   enable_object_storage_module = local.enable_external
   enable_redis_module          = local.active_active
-  fdo_operational_mode         = local.enable_disk ? "disk" : local.active_active ? "active-active" : "external"
+  fdo_operational_mode         = var.operational_mode
   ami_id                       = local.default_ami_id ? data.aws_ami.ubuntu.id : var.ami_id
   default_ami_id               = var.ami_id == null
   fqdn                         = "${var.tfe_subdomain}.${var.domain_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -287,8 +287,8 @@ variable "operational_mode" {
   type        = string
 
   validation {
-    condition     = contains(["external", "disk"], var.operational_mode)
-    error_message = "The operational_mode value must be one of: \"external\"; \"disk\"."
+    condition     = contains(["external", "disk", "active-active"], var.operational_mode)
+    error_message = "The operational_mode value must be one of: \"active-active\", \"external\"; \"disk\"."
   }
 }
 


### PR DESCRIPTION
## Background

This module manages an "active-active" state using the `var.node_count`. This is different from the other modes, which are only based on the variable `operational_mode`. 

This  PR adds `active-active` as a valid value for `var.operational_mode` and the node_count won't affect the active-active status. This change is non-breaking, so consumers using active-active by providing a node_count greater than 2 won't be affected.
