### PR TITLE
[TF-15070] Simplify active-active operational mode

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
-  active_active                = var.node_count >= 2 || var.operational_mode == "active-active"
   kms_key_arn                  = data.aws_kms_key.main.arn
   enable_airgap                = var.airgap_url == null && var.tfe_license_bootstrap_airgap_package_path != null
-  enable_external              = var.operational_mode == "external" || local.active_active
+  enable_external              = var.operational_mode == "external" || var.operational_mode == "active-active"
   enable_disk                  = var.operational_mode == "disk"
   enable_database_module       = local.enable_external
   enable_object_storage_module = local.enable_external
-  enable_redis_module          = local.active_active
+  enable_redis_module          = var.operational_mode == "active-active"
   fdo_operational_mode         = var.operational_mode
   ami_id                       = local.default_ami_id ? data.aws_ami.ubuntu.id : var.ami_id
   default_ami_id               = var.ami_id == null

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ module "redis" {
   source = "./modules/redis"
   count  = local.enable_redis_module ? 1 : 0
 
-  active_active                = local.active_active
+  active_active                = var.operational_mode == "active-active"
   friendly_name_prefix         = var.friendly_name_prefix
   network_id                   = local.network_id
   network_private_subnet_cidrs = var.network_private_subnet_cidrs
@@ -241,7 +241,6 @@ module "settings" {
 
   # Replicated Base Configuration
   hostname                                  = local.fqdn
-  enable_active_active                      = local.active_active
   tfe_license_bootstrap_airgap_package_path = var.tfe_license_bootstrap_airgap_package_path
   tfe_license_file_location                 = var.tfe_license_file_location
   tls_bootstrap_cert_pathname               = var.tls_bootstrap_cert_pathname
@@ -309,7 +308,7 @@ module "load_balancer" {
   count  = var.load_balancing_scheme != "PRIVATE_TCP" ? 1 : 0
   source = "./modules/application_load_balancer"
 
-  active_active                  = local.active_active
+  active_active                  = var.operational_mode == "active-active"
   admin_dashboard_ingress_ranges = var.admin_dashboard_ingress_ranges
   certificate_arn                = var.acm_certificate_arn
   domain_name                    = var.domain_name
@@ -326,7 +325,7 @@ module "private_tcp_load_balancer" {
   count  = var.load_balancing_scheme == "PRIVATE_TCP" ? 1 : 0
   source = "./modules/network_load_balancer"
 
-  active_active           = local.active_active
+  active_active           = var.operational_mode == "active-active"
   certificate_arn         = var.acm_certificate_arn
   domain_name             = var.domain_name
   friendly_name_prefix    = var.friendly_name_prefix
@@ -339,7 +338,7 @@ module "private_tcp_load_balancer" {
 module "vm" {
   source = "./modules/vm"
 
-  active_active                          = local.active_active
+  active_active                          = var.operational_mode == "active-active"
   aws_iam_instance_profile               = module.service_accounts.iam_instance_profile.name
   ami_id                                 = local.ami_id
   aws_lb                                 = var.load_balancing_scheme == "PRIVATE_TCP" ? null : module.load_balancer[0].aws_lb_security_group

--- a/variables.tf
+++ b/variables.tf
@@ -432,7 +432,7 @@ variable "license_reporting_opt_out" {
 variable "node_count" {
   type        = number
   default     = 2
-  description = "The number of nodes you want in your autoscaling group (1 for standalone, 2 for active-active configuration)"
+  description = "The number of nodes you want in your autoscaling group"
 
   validation {
     condition     = var.node_count <= 5


### PR DESCRIPTION
## Background

This PR is a follow-up to: https://github.com/hashicorp/terraform-random-tfe-utility/pull/158. The `enable_active_active` setting doesn't exist anymore.

It also simplifies the `active-active` logic to be dependent on the `operational_mode` argument.