### PR TITLE
Bump example to RHEL8 since 7 is EoL

### DIFF
--- a/examples/active-active-proxy/README.md
+++ b/examples/active-active-proxy/README.md
@@ -7,7 +7,7 @@ This example for Terraform Enterprise creates a TFE installation with the follow
 - Active/Active architecture
 - External Services production type
 - m5.xlarge virtual machine type
-- RHEL 7.9
+- RHEL 8.8
 - A privately accessible TCP load balancer with TLS pass-through
 - An ubuntu based mitm proxy server with TLS termination 
 

--- a/examples/active-active-proxy/data.tf
+++ b/examples/active-active-proxy/data.tf
@@ -16,7 +16,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
+    values = ["RHEL-8.8.0_HVM-*-x86_64-*-Hourly2-GP2"]
   }
 
   filter {

--- a/tests/active-active-rhel7-proxy/README.md
+++ b/tests/active-active-rhel7-proxy/README.md
@@ -7,7 +7,7 @@ following traits:
 
 - Active/Active mode
 - a small VM machine type (m5.xlarge)
-- Red Hat 7.9 as the VM image
+- Red Hat 8.8 as the VM image
 - a publicly accessible HTTP load balancer with TLS termination
 - a proxy server with TLS termination
 - an access key for accessing S3

--- a/tests/active-active-rhel7-proxy/data.tf
+++ b/tests/active-active-rhel7-proxy/data.tf
@@ -24,7 +24,7 @@ data "aws_ami" "rhel" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.9_HVM-*-x86_64-*-Hourly2-GP2"]
+    values = ["RHEL-8.8.0_HVM-*-x86_64-*-Hourly2-GP2"]
   }
 
   filter {


### PR DESCRIPTION
## Background

The Active/Active Proxy example uses RHEL v7, which is end of life at the end of June. This PR bumps the OS to RHEL v8.


Relates OR Closes #0000


## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Test Configuration

* Terraform Version:
* Any additional relevant variables:

## This PR makes me feel

![optional gif describing your feelings about this pr]()
