### PR TITLE
Amazon RDS deployment strategy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,8 @@ module "database" {
   network_subnets_private      = local.network_private_subnets
   tfe_instance_sg              = module.vm.tfe_instance_sg
   kms_key_arn                  = local.kms_key_arn
+  allow_major_version_upgrade  = var.allow_major_version_upgrade
+  allow_multiple_azs           = var.allow_multiple_azs
 }
 
 # -----------------------------------------------------------------------------

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -62,7 +62,7 @@ resource "aws_db_instance" "postgresql" {
   # no special characters allowed
   username = var.db_username
 
-  allow_major_version_upgrade = false
+  allow_major_version_upgrade = var.allow_major_version_upgrade
   apply_immediately           = true
   auto_minor_version_upgrade  = true
   backup_retention_period     = var.db_backup_retention
@@ -73,7 +73,7 @@ resource "aws_db_instance" "postgresql" {
   engine_version              = var.engine_version
   identifier_prefix           = "${var.friendly_name_prefix}-tfe"
   max_allocated_storage       = 0
-  multi_az                    = true
+  multi_az                    = var.allow_multiple_azs
   # no special characters allowed
   db_name                = var.db_name
   port                   = 5432

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -65,3 +65,13 @@ variable "kms_key_arn" {
   description = "The Amazon Resource Name of the KMS key which will be used by the Redis Elasticache replication group to encrypt data at rest."
   type        = string
 }
+
+variable "allow_major_version_upgrade" {
+  type        = bool
+  description = "Determine whether postgres major version upgrade is required or not."
+}
+
+variable "allow_multiple_azs" {
+  type        = bool
+  description = "Determine Amazon RDS Postgres deployment strategy."
+}

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -69,9 +69,11 @@ variable "kms_key_arn" {
 variable "allow_major_version_upgrade" {
   type        = bool
   description = "Determine whether postgres major version upgrade is required or not."
+  default     = false
 }
 
 variable "allow_multiple_azs" {
   type        = bool
   description = "Determine Amazon RDS Postgres deployment strategy."
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,18 @@ variable "postgres_engine_version" {
   description = "PostgreSQL version."
 }
 
+variable "allow_major_version_upgrade" {
+  type        = bool
+  description = "Determine whether postgres major version upgrade is required or not."
+  default     = false
+}
+
+variable "allow_multiple_azs" {
+  type        = bool
+  description = "Determine Amazon RDS Postgres deployment strategy."
+  default     = true
+}
+
 # Aurora
 # ------
 variable "enable_aurora" {


### PR DESCRIPTION
## Background

This PR enables the dynamic setup of Amazon RDS deployment strategies. Previously, the only option was to deploy RDS instances using a Multi-AZ configuration, which, while providing high availability, is costly and can increase release test runtimes.
Some release tests may not require such a high level of availability and can work with the Single-AZ Configuration. Therefore, the ability to dynamically configure deployment strategies offers a more flexible and efficient approach. 
This PR also allows for the dynamic setup of the `allow_major_version_upgrade` variable, further enhancing customization and optimization.

## Relates to 
Postgres Compatibility release test  = https://hashicorp.atlassian.net/browse/TF-16228 

## How Has This Been Tested

The changes do not introduce significant modifications. Care has been taken to ensure that existing release tests are not disrupted by running the following GHA run -: 

made `ci-aws-fdo-docker-active-active-feature` and GHA run
https://github.com/hashicorp/terraform-enterprise/actions/runs/12256134039/job/34190732349

