### PR TITLE
[TF-23439] Removing PostgreSQL Minor Version in AWS Release tests

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -192,7 +192,7 @@ variable "db_size" {
 
 variable "postgres_engine_version" {
   type        = string
-  default     = "12.15"
+  default     = "16"
   description = "PostgreSQL version."
 }
 


### PR DESCRIPTION
CHANGELOG:

no-impact


## Background

This PR removes the dependency on the minor version of PostgreSQL and only specifies the major version for the release tests. This change allows AWS RDS to automatically utilize the latest available minor version for the specified major version at the time of creation.
- [JIRA TF-23439](https://hashicorp.atlassian.net/browse/TF-23439)


## Summary

Currently, some of the release tests associated with the AWS Environment have the minor version of the PostgreSQL Engine hardcoded. Some AWS Release tests have failed due to Amazon RDS discontinuing support for the specific minor version of PostgreSQL. One of the incidents encountered in the following run : https://github.com/hashicorp/terraform-enterprise/actions/runs/12774604392/job/35657266311 where the error was: 
`Error: creating RDS DB Instance (up-coral-tfe20250113001829240000000001): operation error RDS: CreateDBInstance, https response error StatusCode: 400, RequestID: a10524b7-3a93-40bd-8813-95bbedd620b5, api error InvalidParameterCombination: Cannot find version 16.2 for postgres`


## Does this PR make a substantial change to TFE's architecture?

NO, it's a tests only PR.

## How Has This Been Tested

- Made the `docker_active_active_feature` module of the **terraform-enterprise/release/internal/spec/terraform/modules/fdo/aws/docker_active_active_feature/** repository to use this branch (as **docker_active_active_feature** module is using this repository directly )
make `ci-aws-fdo-docker-active-active-feature` and GHA run
Github Run = https://github.com/hashicorp/terraform-enterprise/actions/runs/12884720233
