### PR TITLE
Updating launch templates for IMDSv2

### DIFF
--- a/modules/redis-sentinel/main.tf
+++ b/modules/redis-sentinel/main.tf
@@ -29,7 +29,7 @@ resource "aws_launch_template" "redis_sentinel_leader" {
   metadata_options {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 2
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
   }
 
   block_device_mappings {

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -96,7 +96,7 @@ resource "aws_launch_template" "tfe" {
   metadata_options {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 2
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
   }
 
   block_device_mappings {


### PR DESCRIPTION
## Background

This PR's purpose is to improve Terraform Enterprise's overall security posture by requiring http_tokens to be required in order for us to move to IMDSv2. 

The http_tokens parameter controls whether the instance metadata service requires the use of session tokens, which are a key feature of IMDSv2.

Changing this to `required` value enforces the use of IMDSv2. All requests to the instance metadata service must include a session token, which enhances security by preventing unauthorized access to the instance metadata.



## How Has This Been Tested

Tested internally.


