### PR TITLE
TF-24307: Set aurora_postgres_engine_version Default to 16

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -258,7 +258,7 @@ variable "aurora_db_username" {
 
 variable "aurora_postgres_engine_version" {
   type        = string
-  default     = "16.2"
+  default     = "16"
   description = "Aurora PostgreSQL version."
 }
 


### PR DESCRIPTION
## Background

This pull request includes a minor update to the `variables.tf` file. The change modifies the default value of the `aurora_postgres_engine_version` variable from "16.2" to "16". This is being done so that default deployments select the latest available 16.Y release of PostgreSQL.

Relates OR Closes https://hashicorp.atlassian.net/browse/TF-24307

## How Has This Been Tested

TBD

### Test Configuration

* Terraform Version:
* Any additional relevant variables:

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/sgyKLGTzFQAa8VCpF9/giphy.gif?cid=5a38a5a2a0w2cy6wt5pko22fbcolkp3rqgjcwa4e7ydhkmr4&ep=v1_gifs_search&rid=giphy.gif&ct=g)
