### PR TITLE
Redis output structure fixes

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -51,32 +51,36 @@ locals {
   redis = var.enable_redis_sentinel ? try(
     module.redis_sentinel[0],
     {
-      hostname          = null
-      password          = null
-      username          = null
-      redis_port        = null
-      use_password_auth = null
-      use_tls           = null
-      sentinel_enabled  = var.enable_redis_sentinel
-      sentinel_hosts    = []
-      sentinel_leader   = null
-      sentinel_username = null
-      sentinel_password = null
+      hostname                          = null
+      password                          = null
+      username                          = null
+      redis_port                        = null
+      use_password_auth                 = null
+      use_tls                           = null
+      sentinel_enabled                  = var.enable_redis_sentinel
+      sentinel_hosts                    = []
+      sentinel_leader                   = null
+      sentinel_username                 = null
+      sentinel_password                 = null
+      aws_elasticache_subnet_group_name = null
+      aws_security_group_redis          = null
     }
     ) : try(
     module.redis[0],
     {
-      hostname          = null
-      password          = null
-      username          = null
-      redis_port        = null
-      use_password_auth = null
-      use_tls           = null
-      sentinel_enabled  = var.enable_redis_sentinel
-      sentinel_hosts    = []
-      sentinel_leader   = null
-      sentinel_username = null
-      sentinel_password = null
+      hostname                          = null
+      password                          = null
+      username                          = null
+      redis_port                        = null
+      use_password_auth                 = null
+      use_tls                           = null
+      sentinel_enabled                  = var.enable_redis_sentinel
+      sentinel_hosts                    = []
+      sentinel_leader                   = null
+      sentinel_username                 = null
+      sentinel_password                 = null
+      aws_elasticache_subnet_group_name = null
+      aws_security_group_redis          = null
     }
   )
 

--- a/modules/redis-sentinel/outputs.tf
+++ b/modules/redis-sentinel/outputs.tf
@@ -1,6 +1,36 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+output "hostname" {
+  value       = null
+  description = "The IP address of the primary node in the Redis Elasticache replication group."
+}
+
+output "password" {
+  value       = local.redis_password
+  description = "The password which is required to authenticate to Redis server."
+}
+
+output "username" {
+  value       = local.redis_username
+  description = "The username which is required to authenticate to Redis server."
+}
+
+output "redis_port" {
+  value       = null
+  description = "The port number on which the Redis Elasticache replication group accepts connections."
+}
+
+output "use_password_auth" {
+  value       = var.redis_use_password_auth
+  description = "A boolean which indicates if password authentication is required by the Redis server."
+}
+
+output "use_tls" {
+  value       = false
+  description = "A boolean which indicates if transit encryption is required by Redis server."
+}
+
 output "sentinel_enabled" {
   value       = true
   description = "sentinel is enabled"
@@ -16,42 +46,22 @@ output "sentinel_leader" {
   description = "The name of the Redis Sentinel leader"
 }
 
-output "sentinel_password" {
-  value       = local.sentinel_password
-  description = "the password to authenticate to Redis sentinel"
-}
-
 output "sentinel_username" {
   value       = local.sentinel_username
   description = "the username to authenticate to Redis sentinel"
 }
 
-output "hostname" {
-  value       = null
-  description = "The IP address of the primary node in the Redis Elasticache replication group."
+output "sentinel_password" {
+  value       = local.sentinel_password
+  description = "the password to authenticate to Redis sentinel"
 }
 
-output "redis_port" {
-  value       = null
-  description = "The port number on which the Redis Elasticache replication group accepts connections."
+output "aws_elasticache_subnet_group_name" {
+  value       = ""
+  description = "The name of the subnetwork group in which the Redis Elasticache replication group is deployed."
 }
 
-output "password" {
-  value       = local.redis_password
-  description = "The password which is required to authenticate to Redis server."
-}
-
-output "username" {
-  value       = local.redis_username
-  description = "The username which is required to authenticate to Redis server."
-}
-
-output "use_password_auth" {
-  value       = var.redis_use_password_auth
-  description = "A boolean which indicates if password authentication is required by the Redis server."
-}
-
-output "use_tls" {
-  value       = false
-  description = "A boolean which indicates if transit encryption is required by Redis server."
+output "aws_security_group_redis" {
+  value       = ""
+  description = "The identity of the security group attached to the Redis Elasticache replication group."
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
-  redis_use_password_auth = var.redis_use_password_auth || var.redis_authentication_mode == "PASSWORD" 
+  redis_use_password_auth = var.redis_use_password_auth || var.redis_authentication_mode == "PASSWORD"
 }
 
 resource "random_id" "redis_password" {

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,24 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
-output "aws_elasticache_subnet_group_name" {
-  value       = var.active_active ? aws_elasticache_subnet_group.tfe[0].name : ""
-  description = "The name of the subnetwork group in which the Redis Elasticache replication group is deployed."
-}
-
-output "aws_security_group_redis" {
-  value       = var.active_active ? aws_security_group.redis[0].id : ""
-  description = "The identity of the security group attached to the Redis Elasticache replication group."
-}
-
 output "hostname" {
   value       = var.active_active ? aws_elasticache_replication_group.redis[0].primary_endpoint_address : ""
   description = "The IP address of the primary node in the Redis Elasticache replication group."
-}
-
-output "redis_port" {
-  value       = var.active_active ? aws_elasticache_replication_group.redis[0].port : ""
-  description = "The port number on which the Redis Elasticache replication group accepts connections."
 }
 
 output "password" {
@@ -31,6 +15,11 @@ output "username" {
   description = "The username which is required to create connections with the Redis Elasticache replication group. Defaults to null to maintain the output interface with the redis-sentinel module."
 }
 
+output "redis_port" {
+  value       = var.active_active ? aws_elasticache_replication_group.redis[0].port : ""
+  description = "The port number on which the Redis Elasticache replication group accepts connections."
+}
+
 output "use_password_auth" {
   value       = var.active_active && local.redis_use_password_auth ? true : false
   description = "A boolean which indicates if password authentication is required by the Redis Elasticache replication group."
@@ -39,6 +28,11 @@ output "use_password_auth" {
 output "use_tls" {
   value       = var.active_active ? aws_elasticache_replication_group.redis[0].transit_encryption_enabled : false
   description = "A boolean which indicates if transit encryption is required by the Redis Elasticache replication group."
+}
+
+output "sentinel_enabled" {
+  value       = false
+  description = "sentinel is not enabled"
 }
 
 output "sentinel_hosts" {
@@ -51,17 +45,22 @@ output "sentinel_leader" {
   description = "The name of the Redis Sentinel leader"
 }
 
-output "sentinel_password" {
-  value       = null
-  description = "the password to authenticate to Redis sentinel"
-}
-
 output "sentinel_username" {
   value       = null
   description = "the username to authenticate to Redis sentinel"
 }
 
-output "sentinel_enabled" {
-  value       = false
-  description = "sentinel is not enabled"
+output "sentinel_password" {
+  value       = null
+  description = "the password to authenticate to Redis sentinel"
+}
+
+output "aws_elasticache_subnet_group_name" {
+  value       = var.active_active ? aws_elasticache_subnet_group.tfe[0].name : ""
+  description = "The name of the subnetwork group in which the Redis Elasticache replication group is deployed."
+}
+
+output "aws_security_group_redis" {
+  value       = var.active_active ? aws_security_group.redis[0].id : ""
+  description = "The identity of the security group attached to the Redis Elasticache replication group."
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -44,7 +44,7 @@ variable "redis_port" {
 variable "redis_authentication_mode" {
   description = "The authentincation mode for redis server instances.  Must be one of [USER_AND_PASSWORD, PASSWORD, NONE]."
   type        = string
-  default     = "PASSWORD"
+  default     = "NONE"
   validation {
     condition     = contains(["USER_AND_PASSWORD", "PASSWORD", "NONE"], var.redis_authentication_mode)
     error_message = "Must be one of [USER_AND_PASSWORD, PASSWORD, NONE]."

--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,7 @@ variable "redis_use_password_auth" {
 variable "redis_authentication_mode" {
   description = "The authentincation mode for redis server instances.  Must be one of [USER_AND_PASSWORD, PASSWORD, NONE]."
   type        = string
-  default     = "PASSWORD"
+  default     = "NONE"
   validation {
     condition     = contains(["USER_AND_PASSWORD", "PASSWORD", "NONE"], var.redis_authentication_mode)
     error_message = "Must be one of [USER_AND_PASSWORD, PASSWORD, NONE]."


### PR DESCRIPTION
## Background

#350 added support for redis sentinel but caused a bug in some non-sentinel configurations that prevent an effective terraform plan (active-active with a standard redis cache). This change standardizes the outputs between the modules to fix this issue.


## How Has This Been Tested

Validation through direct branch targeting in TFE release tests.


## This PR makes me feel

<img src="https://media1.giphy.com/media/BsQAVgY6ksvIY/giphy.gif?cid=bd3ea57ekpovazm49b48y061dyczrry5pgro5yhdpf7ql0fh&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>
