### PR TITLE
Add configuration for the new Admin API HTTPS port 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ module "aurora_database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "runtime_container_engine_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=kosy/add-admin-port"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license

--- a/main.tf
+++ b/main.tf
@@ -368,6 +368,7 @@ module "load_balancer" {
 
   active_active                  = var.operational_mode == "active-active"
   admin_dashboard_ingress_ranges = var.admin_dashboard_ingress_ranges
+  admin_api_https_port           = var.admin_api_https_port
   certificate_arn                = var.acm_certificate_arn
   domain_name                    = var.domain_name
   friendly_name_prefix           = var.friendly_name_prefix
@@ -384,6 +385,7 @@ module "private_tcp_load_balancer" {
   source = "./modules/network_load_balancer"
 
   active_active           = var.operational_mode == "active-active"
+  admin_api_https_port    = var.admin_api_https_port
   certificate_arn         = var.acm_certificate_arn
   domain_name             = var.domain_name
   friendly_name_prefix    = var.friendly_name_prefix
@@ -396,12 +398,14 @@ module "private_tcp_load_balancer" {
 module "vm" {
   source = "./modules/vm"
 
-  active_active                          = var.operational_mode == "active-active"
-  aws_iam_instance_profile               = module.service_accounts.iam_instance_profile.name
-  ami_id                                 = local.ami_id
-  aws_lb                                 = var.load_balancing_scheme == "PRIVATE_TCP" ? null : module.load_balancer[0].aws_lb_security_group
-  aws_lb_target_group_tfe_tg_443_arn     = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_443_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_443_arn
-  aws_lb_target_group_tfe_tg_8800_arn    = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn
+  active_active                               = var.operational_mode == "active-active"
+  aws_iam_instance_profile                    = module.service_accounts.iam_instance_profile.name
+  ami_id                                      = local.ami_id
+  aws_lb                                      = var.load_balancing_scheme == "PRIVATE_TCP" ? null : module.load_balancer[0].aws_lb_security_group
+  aws_lb_target_group_tfe_tg_443_arn          = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_443_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_443_arn
+  aws_lb_target_group_tfe_tg_8800_arn         = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn
+  aws_lb_target_group_tfe_tg_admin_api_arn    = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_admin_api_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_admin_api_arn
+  admin_api_https_port                        = var.admin_api_https_port
   asg_tags                               = var.asg_tags
   ec2_launch_template_tag_specifications = var.ec2_launch_template_tag_specifications
   default_ami_id                         = local.default_ami_id

--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ module "aurora_database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "runtime_container_engine_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=kosy/add-admin-port"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license
@@ -179,6 +179,7 @@ module "runtime_container_engine_config" {
   hostname                    = local.fqdn
   http_port                   = var.http_port
   https_port                  = var.https_port
+  admin_api_https_port        = var.admin_api_https_port
   http_proxy                  = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null
   https_proxy                 = var.proxy_ip != null ? "${var.proxy_ip}:${var.proxy_port}" : null
   no_proxy                    = var.proxy_ip != null ? local.no_proxy : null

--- a/main.tf
+++ b/main.tf
@@ -398,34 +398,34 @@ module "private_tcp_load_balancer" {
 module "vm" {
   source = "./modules/vm"
 
-  active_active                               = var.operational_mode == "active-active"
-  aws_iam_instance_profile                    = module.service_accounts.iam_instance_profile.name
-  ami_id                                      = local.ami_id
-  aws_lb                                      = var.load_balancing_scheme == "PRIVATE_TCP" ? null : module.load_balancer[0].aws_lb_security_group
-  aws_lb_target_group_tfe_tg_443_arn          = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_443_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_443_arn
-  aws_lb_target_group_tfe_tg_8800_arn         = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn
-  aws_lb_target_group_tfe_tg_admin_api_arn    = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_admin_api_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_admin_api_arn
-  admin_api_https_port                        = var.admin_api_https_port
-  asg_tags                               = var.asg_tags
-  ec2_launch_template_tag_specifications = var.ec2_launch_template_tag_specifications
-  default_ami_id                         = local.default_ami_id
-  enable_disk                            = local.enable_disk
-  enable_ssh                             = var.enable_ssh
-  ebs_device_name                        = var.ebs_device_name
-  ebs_volume_size                        = var.ebs_volume_size
-  ebs_volume_type                        = var.ebs_volume_type
-  ebs_iops                               = var.ebs_iops
-  ebs_delete_on_termination              = var.ebs_delete_on_termination
-  ebs_snapshot_id                        = var.ebs_snapshot_id
-  friendly_name_prefix                   = var.friendly_name_prefix
-  health_check_grace_period              = var.health_check_grace_period
-  health_check_type                      = var.health_check_type
-  instance_type                          = var.instance_type
-  is_replicated_deployment               = var.is_replicated_deployment
-  key_name                               = var.key_name
-  network_id                             = local.network_id
-  network_subnets_private                = local.network_private_subnets
-  network_private_subnet_cidrs           = local.network_private_subnet_cidrs
-  node_count                             = var.node_count
-  user_data_base64                       = var.is_replicated_deployment ? module.tfe_init_replicated[0].tfe_userdata_base64_encoded : module.tfe_init_fdo[0].tfe_userdata_base64_encoded
+  active_active                            = var.operational_mode == "active-active"
+  aws_iam_instance_profile                 = module.service_accounts.iam_instance_profile.name
+  ami_id                                   = local.ami_id
+  aws_lb                                   = var.load_balancing_scheme == "PRIVATE_TCP" ? null : module.load_balancer[0].aws_lb_security_group
+  aws_lb_target_group_tfe_tg_443_arn       = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_443_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_443_arn
+  aws_lb_target_group_tfe_tg_8800_arn      = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_8800_arn
+  aws_lb_target_group_tfe_tg_admin_api_arn = var.load_balancing_scheme == "PRIVATE_TCP" ? module.private_tcp_load_balancer[0].aws_lb_target_group_tfe_tg_admin_api_arn : module.load_balancer[0].aws_lb_target_group_tfe_tg_admin_api_arn
+  admin_api_https_port                     = var.admin_api_https_port
+  asg_tags                                 = var.asg_tags
+  ec2_launch_template_tag_specifications   = var.ec2_launch_template_tag_specifications
+  default_ami_id                           = local.default_ami_id
+  enable_disk                              = local.enable_disk
+  enable_ssh                               = var.enable_ssh
+  ebs_device_name                          = var.ebs_device_name
+  ebs_volume_size                          = var.ebs_volume_size
+  ebs_volume_type                          = var.ebs_volume_type
+  ebs_iops                                 = var.ebs_iops
+  ebs_delete_on_termination                = var.ebs_delete_on_termination
+  ebs_snapshot_id                          = var.ebs_snapshot_id
+  friendly_name_prefix                     = var.friendly_name_prefix
+  health_check_grace_period                = var.health_check_grace_period
+  health_check_type                        = var.health_check_type
+  instance_type                            = var.instance_type
+  is_replicated_deployment                 = var.is_replicated_deployment
+  key_name                                 = var.key_name
+  network_id                               = local.network_id
+  network_subnets_private                  = local.network_private_subnets
+  network_private_subnet_cidrs             = local.network_private_subnet_cidrs
+  node_count                               = var.node_count
+  user_data_base64                         = var.is_replicated_deployment ? module.tfe_init_replicated[0].tfe_userdata_base64_encoded : module.tfe_init_fdo[0].tfe_userdata_base64_encoded
 }

--- a/modules/application_load_balancer/main.tf
+++ b/modules/application_load_balancer/main.tf
@@ -166,9 +166,9 @@ resource "aws_lb_target_group" "tfe_tg_admin_api" {
   vpc_id   = var.network_id
 
   health_check {
-    path     = "/_health_check"
+    path     = "/api/v1/ping"
     protocol = "HTTPS"
-    matcher  = "200-399"
+    matcher  = "200-399,400,401,403"
   }
 }
 

--- a/modules/application_load_balancer/main.tf
+++ b/modules/application_load_balancer/main.tf
@@ -26,6 +26,16 @@ resource "aws_security_group_rule" "tfe_lb_allow_inbound_https" {
   security_group_id = aws_security_group.tfe_lb_allow.id
 }
 
+resource "aws_security_group_rule" "tfe_lb_allow_inbound_https_admin_api" {
+  type              = "ingress"
+  from_port         = 8446
+  to_port           = 8446
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow HTTPS (port 8446) traffic inbound to TFE LB for Admin API"
+  security_group_id = aws_security_group.tfe_lb_allow.id
+}
+
 resource "aws_security_group_rule" "tfe_lb_allow_inbound_dashboard" {
   count             = var.active_active ? 0 : 1
   type              = "ingress"

--- a/modules/application_load_balancer/main.tf
+++ b/modules/application_load_balancer/main.tf
@@ -164,6 +164,12 @@ resource "aws_lb_target_group" "tfe_tg_admin_api" {
   port     = var.admin_api_https_port
   protocol = "HTTPS"
   vpc_id   = var.network_id
+
+  health_check {
+    path     = "/_health_check"
+    protocol = "HTTPS"
+    matcher  = "200-399"
+  }
 }
 
 data "aws_route53_zone" "tfe" {

--- a/modules/application_load_balancer/outputs.tf
+++ b/modules/application_load_balancer/outputs.tf
@@ -19,6 +19,12 @@ output "aws_lb_target_group_tfe_tg_8800_arn" {
   description = "The Amazon Resource Name of the load balancer target group for traffic on port 8800."
 }
 
+output "aws_lb_target_group_tfe_tg_admin_api_arn" {
+  value = aws_lb_target_group.tfe_tg_admin_api.arn
+
+  description = "The Amazon Resource Name of the load balancer target group for traffic on the Admin API HTTPS port."
+}
+
 output "load_balancer_address" {
   value = aws_lb.tfe_lb.dns_name
 

--- a/modules/application_load_balancer/variables.tf
+++ b/modules/application_load_balancer/variables.tf
@@ -60,3 +60,8 @@ variable "friendly_name_prefix" {
   type        = string
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
 }
+
+variable "admin_api_https_port" {
+  type        = number
+  description = "Port application listens on for Admin API HTTPS."
+}

--- a/modules/network_load_balancer/main.tf
+++ b/modules/network_load_balancer/main.tf
@@ -30,6 +30,28 @@ resource "aws_lb_target_group" "tfe_tg_443" {
   }
 }
 
+resource "aws_lb_target_group" "tfe_tg_8446" {
+  name     = "${var.friendly_name_prefix}-tfe-alb-tg-8446"
+  port     = 8446
+  protocol = "TCP"
+  vpc_id   = var.network_id
+
+  health_check {
+    protocol = "TCP"
+  }
+}
+
+resource "aws_lb_listener" "tfe_listener_8446" {
+  load_balancer_arn = aws_lb.tfe_lb.arn
+  port              = 8446
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tfe_tg_8446.arn
+  }
+}
+
 resource "aws_lb_listener" "tfe_listener_8800" {
   count             = var.active_active ? 0 : 1
   load_balancer_arn = aws_lb.tfe_lb.arn

--- a/modules/network_load_balancer/main.tf
+++ b/modules/network_load_balancer/main.tf
@@ -30,28 +30,6 @@ resource "aws_lb_target_group" "tfe_tg_443" {
   }
 }
 
-resource "aws_lb_target_group" "tfe_tg_8446" {
-  name     = "${var.friendly_name_prefix}-tfe-alb-tg-8446"
-  port     = 8446
-  protocol = "TCP"
-  vpc_id   = var.network_id
-
-  health_check {
-    protocol = "TCP"
-  }
-}
-
-resource "aws_lb_listener" "tfe_listener_8446" {
-  load_balancer_arn = aws_lb.tfe_lb.arn
-  port              = 8446
-  protocol          = "TCP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.tfe_tg_8446.arn
-  }
-}
-
 resource "aws_lb_listener" "tfe_listener_8800" {
   count             = var.active_active ? 0 : 1
   load_balancer_arn = aws_lb.tfe_lb.arn
@@ -76,6 +54,28 @@ resource "aws_lb_target_group" "tfe_tg_8800" {
 
   health_check {
     path     = "/"
+    protocol = "TCP"
+  }
+}
+
+resource "aws_lb_listener" "tfe_listener_admin_api" {
+  load_balancer_arn = aws_lb.tfe_lb.arn
+  port              = var.admin_api_https_port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tfe_tg_admin_api.arn
+  }
+}
+
+resource "aws_lb_target_group" "tfe_tg_admin_api" {
+  name     = "${var.friendly_name_prefix}-tfe-nlb-tg-${var.admin_api_https_port}"
+  port     = var.admin_api_https_port
+  protocol = "TCP"
+  vpc_id   = var.network_id
+
+  health_check {
     protocol = "TCP"
   }
 }

--- a/modules/network_load_balancer/outputs.tf
+++ b/modules/network_load_balancer/outputs.tf
@@ -18,3 +18,9 @@ output "load_balancer_address" {
 
   description = "The DNS name of the load balancer."
 }
+
+output "aws_lb_target_group_tfe_tg_admin_api_arn" {
+  value = aws_lb_target_group.tfe_tg_admin_api.arn
+
+  description = "The Amazon Resource Name of the load balancer target group for traffic on the Admin API HTTPS port."
+}

--- a/modules/network_load_balancer/variables.tf
+++ b/modules/network_load_balancer/variables.tf
@@ -40,3 +40,8 @@ variable "friendly_name_prefix" {
   type        = string
   description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
 }
+
+variable "admin_api_https_port" {
+  type        = number
+  description = "Port application listens on for Admin API HTTPS."
+}

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -149,7 +149,7 @@ resource "aws_autoscaling_group" "tfe_asg" {
   target_group_arns = var.active_active || !var.is_replicated_deployment ? [
     var.aws_lb_target_group_tfe_tg_443_arn,
     var.aws_lb_target_group_tfe_tg_admin_api_arn,
-  ] : [
+    ] : [
     var.aws_lb_target_group_tfe_tg_8800_arn,
     var.aws_lb_target_group_tfe_tg_443_arn,
     var.aws_lb_target_group_tfe_tg_admin_api_arn,

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -26,6 +26,16 @@ variable "aws_lb_target_group_tfe_tg_8800_arn" {
   type        = string
 }
 
+variable "aws_lb_target_group_tfe_tg_admin_api_arn" {
+  description = "The Amazon Resource Name of the load balancer target group for traffic on the Admin API HTTPS port which will be backed by the TFE EC2 autoscaling group."
+  type        = string
+}
+
+variable "admin_api_https_port" {
+  type        = number
+  description = "Port application listens on for Admin API HTTPS."
+}
+
 variable "aws_iam_instance_profile" {
   description = "The name of the IAM instance profile to be associated with the TFE EC2 instance(s)."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -345,8 +345,8 @@ variable "https_port" {
 }
 
 variable "admin_api_https_port" {
-  default = 8446
-  type    = number
+  default     = 8446
+  type        = number
   description = "(Optional if is_replicated_deployment is false) Port application listens on for Admin API HTTPS. Default is 8443."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -344,6 +344,12 @@ variable "https_port" {
   description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTPS. Default is 443."
 }
 
+variable "admin_api_https_port" {
+  default = 8446
+  type    = number
+  description = "(Optional if is_replicated_deployment is false) Port application listens on for Admin API HTTPS. Default is 8443."
+}
+
 variable "iact_subnet_list" {
   default     = []
   description = "A list of CIDR masks that configure the ability to retrieve the IACT from outside the host."


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/TF-26458)

## Background

The API endpoint on the CV instance is currently inaccessible due to a conflicting server name error. This issue needs to be resolved by defining a new port and configuring security rules on AWS.


## How Has This Been Tested
Via https://github.com/hashicorp/ptfedev-infra/pull/815. I used it to validate access to the admin API.


Made this PR because the license check was stuck in the old PR https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/353