### PR TITLE
Support for Redis sentinel release test

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -201,7 +201,7 @@ module "aurora_database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "runtime_container_engine_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=TF-24345/redis-sentinel"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license
@@ -280,7 +280,7 @@ module "runtime_container_engine_config" {
 # AWS cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # --------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=TF-24345/redis-sentinel"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "aws"
@@ -319,7 +319,7 @@ module "tfe_init_fdo" {
 # TFE and Replicated settings to pass to the tfe_init_replicated module for replicated deployment
 # --------------------------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=TF-24345/redis-sentinel"
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE Base Configuration
@@ -381,7 +381,7 @@ module "settings" {
 # AWS user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init_replicated" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=TF-24345/redis-sentinel"
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE & Replicated Configuration data

--- a/main.tf
+++ b/main.tf
@@ -102,10 +102,7 @@ module "redis_sentinel" {
   count  = var.enable_redis_sentinel ? 1 : 0
   source = "./modules/redis-sentinel"
 
-  sentinel_hosts                         = var.sentinel_hosts
   sentinel_leader                        = var.sentinel_leader
-  sentinel_username                      = var.sentinel_username
-  sentinel_password                      = var.sentinel_password
   domain_name                            = var.domain_name
   redis_authentication_mode              = var.redis_authentication_mode
   sentinel_authentication_mode           = var.sentinel_authentication_mode

--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,7 @@ module "aurora_database" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "runtime_container_engine_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=TF-24345/redis-sentinel"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   tfe_license = var.hc_license
@@ -281,7 +281,7 @@ module "runtime_container_engine_config" {
 # AWS cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # --------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=TF-24345/redis-sentinel"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "aws"
@@ -320,7 +320,7 @@ module "tfe_init_fdo" {
 # TFE and Replicated settings to pass to the tfe_init_replicated module for replicated deployment
 # --------------------------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=TF-24345/redis-sentinel"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE Base Configuration
@@ -382,7 +382,7 @@ module "settings" {
 # AWS user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init_replicated" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=TF-24345/redis-sentinel"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=main"
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE & Replicated Configuration data

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ module "redis" {
   redis_encryption_in_transit = var.redis_encryption_in_transit
   redis_encryption_at_rest    = var.redis_encryption_at_rest
   redis_use_password_auth     = var.redis_use_password_auth
-  redis_port                  = var.redis_encryption_in_transit ? "6380" : "6379"  
+  redis_port                  = var.redis_encryption_in_transit ? "6380" : "6379"
 }
 
 # -----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ module "redis" {
   redis_encryption_in_transit = var.redis_encryption_in_transit
   redis_encryption_at_rest    = var.redis_encryption_at_rest
   redis_use_password_auth     = var.redis_use_password_auth
-  redis_port                  = var.redis_encryption_in_transit ? "6380" : "6379"
+  redis_port                  = var.redis_encryption_in_transit ? "6380" : "6379"  
 }
 
 # -----------------------------------------------------------------------------
@@ -102,6 +102,10 @@ module "redis_sentinel" {
   count  = var.enable_redis_sentinel ? 1 : 0
   source = "./modules/redis-sentinel"
 
+  redis_sentinel_hosts                   = var.sentinel_hosts
+  redis_sentinel_leader_name             = var.sentinel_leader
+  redis_sentinel_username                = var.sentinel_username
+  redis_sentinel_password                = var.sentinel_password
   domain_name                            = var.domain_name
   redis_authentication_mode              = var.redis_authentication_mode
   sentinel_authentication_mode           = var.sentinel_authentication_mode

--- a/main.tf
+++ b/main.tf
@@ -102,10 +102,10 @@ module "redis_sentinel" {
   count  = var.enable_redis_sentinel ? 1 : 0
   source = "./modules/redis-sentinel"
 
-  redis_sentinel_hosts                   = var.sentinel_hosts
-  redis_sentinel_leader_name             = var.sentinel_leader
-  redis_sentinel_username                = var.sentinel_username
-  redis_sentinel_password                = var.sentinel_password
+  sentinel_hosts                         = var.sentinel_hosts
+  sentinel_leader                        = var.sentinel_leader
+  sentinel_username                      = var.sentinel_username
+  sentinel_password                      = var.sentinel_password
   domain_name                            = var.domain_name
   redis_authentication_mode              = var.redis_authentication_mode
   sentinel_authentication_mode           = var.sentinel_authentication_mode

--- a/modules/redis-sentinel/locals.tf
+++ b/modules/redis-sentinel/locals.tf
@@ -21,7 +21,7 @@ locals {
     sentinel_start_script = base64encode(templatefile(local.sentinel_start_script_path, {
       redis_sentinel_password    = local.sentinel_password
       redis_sentinel_username    = local.sentinel_username
-      redis_sentinel_leader_name = var.redis_sentinel_leader_name
+      redis_sentinel_leader_name = var.sentinel_leader
       redis_sentinel_port        = var.redis_sentinel_port
       redis_port                 = var.redis_port
       redis_password             = local.redis_password

--- a/modules/redis-sentinel/main.tf
+++ b/modules/redis-sentinel/main.tf
@@ -16,7 +16,7 @@ resource "random_pet" "redis_username" {
   count = var.redis_authentication_mode == "USER_AND_PASSWORD" ? 1 : 0
 }
 
-resource "random_password" "sentinel_password" {
+resource "random_password" "redis_sentinel_password" {
   count            = contains(["USER_AND_PASSWORD", "PASSWORD"], var.sentinel_authentication_mode) ? 1 : 0
   length           = 16
   special          = true

--- a/modules/redis-sentinel/main.tf
+++ b/modules/redis-sentinel/main.tf
@@ -90,7 +90,7 @@ resource "aws_autoscaling_group" "redis_sentinel" {
   health_check_type         = var.health_check_type
 
   launch_template {
-    id      = aws_launch_template.redis_sentinel_leader.id
+    id      = aws_launch_template.sentinel_leader.id
     version = "$Latest"
   }
 

--- a/modules/redis-sentinel/main.tf
+++ b/modules/redis-sentinel/main.tf
@@ -16,7 +16,7 @@ resource "random_pet" "redis_username" {
   count = var.redis_authentication_mode == "USER_AND_PASSWORD" ? 1 : 0
 }
 
-resource "random_password" "redis_sentinel_password" {
+resource "random_password" "sentinel_password" {
   count            = contains(["USER_AND_PASSWORD", "PASSWORD"], var.sentinel_authentication_mode) ? 1 : 0
   length           = 16
   special          = true
@@ -28,7 +28,7 @@ resource "random_pet" "sentinel_username" {
 }
 
 
-resource "aws_launch_template" "redis_sentinel_leader" {
+resource "aws_launch_template" "sentinel_leader" {
   name_prefix            = "${var.friendly_name_prefix}-redis-sentinel-leader"
   image_id               = data.aws_ami.ubuntu.id
   instance_type          = var.instance_type

--- a/modules/redis-sentinel/outputs.tf
+++ b/modules/redis-sentinel/outputs.tf
@@ -6,12 +6,12 @@ output "hostname" {
   description = "The IP address of the primary node in the Redis Elasticache replication group."
 }
 
-output "password" {
+output "redis_password" {
   value       = local.redis_password
   description = "The password which is required to authenticate to Redis server."
 }
 
-output "username" {
+output "redis_username" {
   value       = local.redis_username
   description = "The username which is required to authenticate to Redis server."
 }

--- a/modules/redis-sentinel/outputs.tf
+++ b/modules/redis-sentinel/outputs.tf
@@ -42,7 +42,7 @@ output "sentinel_hosts" {
 }
 
 output "sentinel_leader" {
-  value       = var.redis_sentinel_leader_name
+  value       = var.sentinel_leader
   description = "The name of the Redis Sentinel leader"
 }
 

--- a/modules/redis-sentinel/outputs.tf
+++ b/modules/redis-sentinel/outputs.tf
@@ -6,12 +6,12 @@ output "hostname" {
   description = "The IP address of the primary node in the Redis Elasticache replication group."
 }
 
-output "redis_password" {
+output "password" {
   value       = local.redis_password
   description = "The password which is required to authenticate to Redis server."
 }
 
-output "redis_username" {
+output "username" {
   value       = local.redis_username
   description = "The username which is required to authenticate to Redis server."
 }

--- a/modules/redis-sentinel/variables.tf
+++ b/modules/redis-sentinel/variables.tf
@@ -105,21 +105,21 @@ variable "redis_sentinel_leader_name" {
 }
 
 variable "redis_sentinel_hosts" {
-  type          = list(string)
-  default       = []
-  description   = "The host/port combinations for available Redis sentinel endpoints."
+  type        = list(string)
+  default     = []
+  description = "The host/port combinations for available Redis sentinel endpoints."
 }
 
 variable "redis_sentinel_username" {
-  type          = string
-  default       = null
-  description   = "the username to authenticate to Redis sentinel"
+  type        = string
+  default     = null
+  description = "the username to authenticate to Redis sentinel"
 }
 
 variable "redis_sentinel_password" {
-  type          = string
-  default       = null
-  description   = "the password to authenticate to Redis sentinel"
+  type        = string
+  default     = null
+  description = "the password to authenticate to Redis sentinel"
 }
 
 variable "redis_authentication_mode" {

--- a/modules/redis-sentinel/variables.tf
+++ b/modules/redis-sentinel/variables.tf
@@ -98,25 +98,25 @@ variable "redis_port" {
   default     = 6379
 }
 
-variable "redis_sentinel_leader_name" {
+variable "sentinel_leader_name" {
   description = "The redis sentinel leader hostname"
   type        = string
   default     = "main"
 }
 
-variable "redis_sentinel_hosts" {
+variable "sentinel_hosts" {
   type        = list(string)
   default     = []
   description = "The host/port combinations for available Redis sentinel endpoints."
 }
 
-variable "redis_sentinel_username" {
+variable "sentinel_username" {
   type        = string
   default     = null
   description = "the username to authenticate to Redis sentinel"
 }
 
-variable "redis_sentinel_password" {
+variable "sentinel_password" {
   type        = string
   default     = null
   description = "the password to authenticate to Redis sentinel"

--- a/modules/redis-sentinel/variables.tf
+++ b/modules/redis-sentinel/variables.tf
@@ -98,7 +98,7 @@ variable "redis_port" {
   default     = 6379
 }
 
-variable "sentinel_leader_name" {
+variable "sentinel_leader" {
   description = "The redis sentinel leader hostname"
   type        = string
   default     = "main"

--- a/modules/redis-sentinel/variables.tf
+++ b/modules/redis-sentinel/variables.tf
@@ -104,24 +104,6 @@ variable "sentinel_leader" {
   default     = "main"
 }
 
-variable "sentinel_hosts" {
-  type        = list(string)
-  default     = []
-  description = "The host/port combinations for available Redis sentinel endpoints."
-}
-
-variable "sentinel_username" {
-  type        = string
-  default     = null
-  description = "the username to authenticate to Redis sentinel"
-}
-
-variable "sentinel_password" {
-  type        = string
-  default     = null
-  description = "the password to authenticate to Redis sentinel"
-}
-
 variable "redis_authentication_mode" {
   description = "The authentincation mode for redis server instances.  Must be one of [USER_AND_PASSWORD, PASSWORD, NONE]."
   type        = string

--- a/modules/redis-sentinel/variables.tf
+++ b/modules/redis-sentinel/variables.tf
@@ -104,6 +104,24 @@ variable "redis_sentinel_leader_name" {
   default     = "main"
 }
 
+variable "redis_sentinel_hosts" {
+  type          = list(string)
+  default       = []
+  description   = "The host/port combinations for available Redis sentinel endpoints."
+}
+
+variable "redis_sentinel_username" {
+  type          = string
+  default       = null
+  description   = "the username to authenticate to Redis sentinel"
+}
+
+variable "redis_sentinel_password" {
+  type          = string
+  default       = null
+  description   = "the password to authenticate to Redis sentinel"
+}
+
 variable "redis_authentication_mode" {
   description = "The authentincation mode for redis server instances.  Must be one of [USER_AND_PASSWORD, PASSWORD, NONE]."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -196,28 +196,10 @@ variable "sentinel_authentication_mode" {
   }
 }
 
-variable "sentinel_hosts" {
-  type        = list(string)
-  default     = []
-  description = "The host/port combinations for available Redis sentinel endpoints."
-}
-
 variable "sentinel_leader" {
   type        = string
   default     = null
   description = "The name of the Redis Sentinel leader"
-}
-
-variable "sentinel_username" {
-  type        = string
-  default     = null
-  description = "the username to authenticate to Redis sentinel"
-}
-
-variable "sentinel_password" {
-  type        = string
-  default     = null
-  description = "the password to authenticate to Redis sentinel"
 }
 
 # Postgres

--- a/variables.tf
+++ b/variables.tf
@@ -198,7 +198,7 @@ variable "sentinel_authentication_mode" {
 
 variable "sentinel_leader" {
   type        = string
-  default     = null
+  default     = "main"
   description = "The name of the Redis Sentinel leader"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,36 @@ variable "sentinel_authentication_mode" {
   }
 }
 
+variable "sentinel_enabled" {
+  type          = bool
+  default       = false
+  description   = "sentinel is not enabled"
+}
+
+variable "sentinel_hosts" {
+  type          = list(string)
+  default       = []
+  description   = "The host/port combinations for available Redis sentinel endpoints."
+}
+
+variable "sentinel_leader" {
+  type          = string
+  default       = null
+  description   = "The name of the Redis Sentinel leader"
+}
+
+variable "sentinel_username" {
+  type          = string
+  default       = null
+  description   = "the username to authenticate to Redis sentinel"
+}
+
+variable "sentinel_password" {
+  type          = string
+  default       = null
+  description   = "the password to authenticate to Redis sentinel"
+}
+
 # Postgres
 # --------
 variable "db_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -197,33 +197,33 @@ variable "sentinel_authentication_mode" {
 }
 
 variable "sentinel_enabled" {
-  type          = bool
-  default       = false
-  description   = "sentinel is not enabled"
+  type        = bool
+  default     = false
+  description = "sentinel is not enabled"
 }
 
 variable "sentinel_hosts" {
-  type          = list(string)
-  default       = []
-  description   = "The host/port combinations for available Redis sentinel endpoints."
+  type        = list(string)
+  default     = []
+  description = "The host/port combinations for available Redis sentinel endpoints."
 }
 
 variable "sentinel_leader" {
-  type          = string
-  default       = null
-  description   = "The name of the Redis Sentinel leader"
+  type        = string
+  default     = null
+  description = "The name of the Redis Sentinel leader"
 }
 
 variable "sentinel_username" {
-  type          = string
-  default       = null
-  description   = "the username to authenticate to Redis sentinel"
+  type        = string
+  default     = null
+  description = "the username to authenticate to Redis sentinel"
 }
 
 variable "sentinel_password" {
-  type          = string
-  default       = null
-  description   = "the password to authenticate to Redis sentinel"
+  type        = string
+  default     = null
+  description = "the password to authenticate to Redis sentinel"
 }
 
 # Postgres

--- a/variables.tf
+++ b/variables.tf
@@ -196,12 +196,6 @@ variable "sentinel_authentication_mode" {
   }
 }
 
-variable "sentinel_enabled" {
-  type        = bool
-  default     = false
-  description = "sentinel is not enabled"
-}
-
 variable "sentinel_hosts" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## Background

Add sentinel vars at the top level so `terraform-enterprise` can use them. The ultimate goal is a release test of Redis Sentinel.


Relates OR Closes #0000


## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Test Configuration

* Terraform Version:
* Any additional relevant variables:

## This PR makes me feel

![optional gif describing your feelings about this pr]()
