### PR TITLE
aurora minor version upgrade for the 1.0.0 release

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -333,7 +333,7 @@ variable "aurora_db_username" {
 
 variable "aurora_postgres_engine_version" {
   type        = string
-  default     = "16.2"
+  default     = "16.9"
   description = "Aurora PostgreSQL version."
 }
 


### PR DESCRIPTION
## Background
Minor version upgrade for AWS aurora as part of 1.0.0 pre-app deadline [TF-27116](https://hashicorp.atlassian.net/browse/TF-27116). 16.2 is upgraded to [16.9](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html#aurorapostgresql-versions-version169x )



## How Has This Been Tested

No


[TF-27116]: https://hashicorp.atlassian.net/browse/TF-27116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ