### PR TITLE
Fixing the default reference to the explorer database outputs 

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -20,6 +20,8 @@ locals {
   network_public_subnets          = var.deploy_vpc ? module.networking[0].network_public_subnets : var.network_public_subnets
   network_private_subnet_cidrs    = var.deploy_vpc ? module.networking[0].network_private_subnet_cidrs : var.network_private_subnet_cidrs
 
+  explorer_database = try(module.explorer_database[0], local.default_database)
+
   default_database = {
     name       = null
     password   = null

--- a/main.tf
+++ b/main.tf
@@ -292,11 +292,11 @@ module "runtime_container_engine_config" {
   database_client_cert_file = "/etc/ssl/private/terraform-enterprise/postgres/cert.crt"
   database_client_key_file  = "/etc/ssl/private/terraform-enterprise/postgres/key.key"
 
-  explorer_database_name       = module.explorer_database.name
-  explorer_database_user       = module.explorer_database.username
-  explorer_database_password   = module.explorer_database.password
-  explorer_database_host       = module.explorer_database.endpoint
-  explorer_database_parameters = module.explorer_database.parameters
+  explorer_database_name       = local.explorer_database.name
+  explorer_database_user       = local.explorer_database.username
+  explorer_database_password   = local.explorer_database.password
+  explorer_database_host       = local.explorer_database.endpoint
+  explorer_database_parameters = local.explorer_database.parameters
 
   storage_type                         = "s3"
   s3_access_key_id                     = var.aws_access_key_id


### PR DESCRIPTION
## Background

#370 will likely cause problems in non-explorer cases and is likely to be problematic because of the case toggle on the explorer module without the indexed reference in usage in main.tf.  This change uses the default-null pattern used for other optional modules to resolve this.

Relates OR Closes #0000


## How Has This Been Tested

terraform validate,  additional testing is needed

## This PR makes me feel

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZHJsZjlnMWV4cTdybno5YWFlMXplbzNnNHJnYzdhYTB4ZmRsZ28wYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l4jL2IVH9IgQifV6K6/giphy.gif"/>
