### PR TITLE
Added validation 'db_use_mtls' variable and updated min tf req to 1.9.0

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -24,9 +24,9 @@ jobs:
         persist-credentials: false
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: 0.14.7
+        terraform_version: 1.9.0
 
     - name: Format all .tf files recursively
       run: |
@@ -46,13 +46,13 @@ jobs:
         persist-credentials: false
 
     - name: Setup Terraform Lint
-      uses: terraform-linters/setup-tflint@ba6bb2989f94daf58a4cc6eac2c1ca7398a678bf # v3.0.0
+      uses: terraform-linters/setup-tflint@ae78205cfffec9e8d93fd2b3115c7e9d3166d4b6 # v5.0.0
       with:
-        tflint_version: v0.26.0
+        tflint_version: v0.59.1
 
     - name: Lint root module
       run: |
-        tflint --config ${{ github.workspace }}/.tflint.hcl ${{ github.workspace }}
+        tflint --config ${{ github.workspace }}/.tflint.hcl --chdir ${{ github.workspace }}
 
     - name: Lint modules directory in a loop
       run: |
@@ -60,7 +60,7 @@ jobs:
         do
           tflint \
             --config ${{ github.workspace }}/.tflint.hcl \
-            ${{ github.workspace }}/${m}
+            --chdir ${{ github.workspace }}/${m}
         done
 
     - name: Lint tests directory in a loop
@@ -69,7 +69,7 @@ jobs:
         do
           tflint \
             --config ${{ github.workspace }}/.tflint.hcl \
-            ${{ github.workspace }}/${m}
+            --chdir ${{ github.workspace }}/${m}
         done
 
     - name: Lint examples directory in a loop
@@ -78,5 +78,5 @@ jobs:
         do
           tflint \
             --config ${{ github.workspace }}/.tflint.hcl \
-            ${{ github.workspace }}/${m}
+            --chdir ${{ github.workspace }}/${m}
         done

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 config {
-  module = false
+  call_module_type = "none"
   force = false
   disabled_by_default = false
 }

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ As the goal for this main module is to provide a drop-in solution for installing
 
 This module is intended to run in an AWS account with minimal preparation, however it does have the following pre-requisites:
 
-### Terraform version >= 0.14
+### Terraform version >= 1.9.0
 
-This module requires Terraform version `0.14` or greater to be installed on the running machine.
+This module requires Terraform version `1.9.0` or greater to be installed on the running machine.
 
 ### Credentials / Permissions
 

--- a/locals.tf
+++ b/locals.tf
@@ -36,7 +36,6 @@ locals {
   standard_db     = try(module.database[0], local.default_database)
 
   selected_database = (
-    var.enable_aurora && var.db_use_mtls ? error("Both enable_aurora and db_use_mtls cannot be true.") :
     var.enable_aurora ? local.aurora_database :
     var.db_use_mtls ? local.mtls_database :
     local.standard_db

--- a/modules/redis-sentinel/locals.tf
+++ b/modules/redis-sentinel/locals.tf
@@ -17,7 +17,7 @@ locals {
       redis_username = local.redis_username
       redis_password = local.redis_password
     }))
-    lbname = "${aws_route53_record.sentinel.fqdn}"
+    lbname = aws_route53_record.sentinel.fqdn
     compose = var.enable_sentinel_mtls ? base64encode(templatefile(local.compose_path_tls, {
       redis_sentinel_port = var.redis_sentinel_port
       redis_port          = var.redis_port
@@ -30,7 +30,7 @@ locals {
       redis_sentinel_leader_name = var.sentinel_leader
       redis_sentinel_port        = var.redis_sentinel_port
       redis_port                 = var.redis_port
-      lbname                     = "${aws_route53_record.sentinel.fqdn}"
+      lbname                     = aws_route53_record.sentinel.fqdn
       })) : base64encode(templatefile(local.sentinel_start_script_path, {
       redis_sentinel_password    = local.sentinel_password
       redis_sentinel_username    = local.sentinel_username

--- a/variables.tf
+++ b/variables.tf
@@ -268,6 +268,10 @@ variable "db_use_mtls" {
   type        = bool
   description = "Whether or not to use mutual TLS to access database. Defaults to false if no value is given."
   default     = false
+  validation {
+    condition     = !(var.db_use_mtls && var.enable_aurora)
+    error_message = "Both db_use_mtls and enable_aurora cannot be true at the same time."
+  }
 }
 
 variable "postgres_ca_certificate_secret_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Background

I have added validation `db_use_mtls` to give error when `db_use_mtls` and `enable_aurora` both variable are true.

## Why?
to improve the developer experience

## How?
I have added validation block in `db_use_mtls` variable and cross reference `enable_aurora` variable, to cross reference min [tf version should be `1.9.0`](https://discuss.hashicorp.com/t/experiment-feedback-input-variable-validation-can-cross-reference-other-objects/66644) so I have updated min tf version requirement to `1.9.0`, I had to also updated tflint version in workflow as older version gives error on cross referencing variable in validation.

also updated tflint command and config as newer version have removed options/feature marked as deprecated:
- added `--chdir` option in tflint command
- replace `module = false` to `call_module_type = "none"` in tflint config (`.tflint.hcl`)

## Testing?
tested changes locally by setting `db_use_mtls` and `enable_aurora` variable true and false, see below screenshot

## Screenshots
| Scenario       | Screenshot        |
|------------|--------------------|
| `✅db_use_mtls`, `✅enable_aurora`     | <img width="541" height="179" alt="image" src="https://github.com/user-attachments/assets/54dbae89-e54d-49b2-9639-50f916eee1c8" /> |
| `✅db_use_mtls`, `❌enable_aurora`      | no error<br/> <img width="347" height="179" alt="image" src="https://github.com/user-attachments/assets/599ae885-8525-40b7-911d-4cbd1edce788" /> |
| `❌db_use_mtls`, `✅enable_aurora`     | no error<br/> <img width="347" height="179" alt="image" src="https://github.com/user-attachments/assets/bab53d58-c298-424e-89aa-7e53af28d35a" />|
| `❌db_use_mtls`, `❌enable_aurora`     | no error<br/> <img width="347" height="179" alt="image" src="https://github.com/user-attachments/assets/97d15b04-df25-41f7-9ea4-bfb5724b1173" />|

release test also passed - https://github.com/hashicorp/terraform-enterprise/actions/runs/17382920555

note: one of the azure release test is falling due to an allocation error, which is not related to version changes.

## How Has This Been Tested

Ran Locally to check error behavior and its working as expected


### Test Configuration

* Terraform Version: 1.13.0
* Any additional relevant variables: set `db_use_mtls` and `enable_aurora` true, it will show error in `terraform plan`

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXpneHF5aGh2M2EzcHA5aWZuejZoaXJpb2gydG5mdmpoenhoMjdsbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SKGo6OYe24EBG/giphy.gif)
