### PR TITLE
Add AWS IAM PostgreSQL passwordless authentication support

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -31,13 +31,15 @@ locals {
     parameters = null
   }
 
-  aurora_database = try(module.aurora_database[0], local.default_database)
-  mtls_database   = try(module.database_mtls[0], local.default_database)
-  enterprise_db   = try(module.edb[0], local.default_database)
-  standard_db     = try(module.database[0], local.default_database)
+  aurora_database       = try(module.aurora_database[0], local.default_database)
+  mtls_database         = try(module.database_mtls[0], local.default_database)
+  enterprise_db         = try(module.edb[0], local.default_database)
+  standard_db           = try(module.database[0], local.default_database)
 
   selected_database = (
     var.enable_aurora && var.db_use_mtls ? error("Both enable_aurora and db_use_mtls cannot be true.") :
+    var.enable_aurora && var.postgres_enable_iam_auth ? error("Both enable_aurora and postgres_enable_iam_auth cannot be true.") :
+    var.db_use_mtls && var.postgres_enable_iam_auth ? error("Both db_use_mtls and postgres_enable_iam_auth cannot be true.") :
     var.enable_aurora ? local.aurora_database :
     var.db_use_mtls ? local.mtls_database :
     var.enable_edb ? local.enterprise_db :

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -83,4 +83,7 @@ resource "aws_db_instance" "postgresql" {
   kms_key_id             = var.kms_key_arn
   storage_type           = "gp2"
   vpc_security_group_ids = [aws_security_group.postgresql.id]
+  
+  # Enable IAM database authentication if requested
+  iam_database_authentication_enabled = var.enable_iam_database_authentication
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -77,3 +77,9 @@ variable "allow_multiple_azs" {
   description = "Determine Amazon RDS Postgres deployment strategy."
   default     = true
 }
+
+variable "enable_iam_database_authentication" {
+  type        = bool
+  description = "Enable IAM database authentication for the RDS instance."
+  default     = false
+}

--- a/modules/postgres-passwordless/README.md
+++ b/modules/postgres-passwordless/README.md
@@ -1,0 +1,53 @@
+# postgres-passwordless Module
+
+This module provisions a PostgreSQL instance with passwordless authentication on an EC2 instance for use with Terraform Enterprise. This module follows the same pattern as the `database-mtls` module but without certificate handling.
+
+## Features
+- EC2-based PostgreSQL deployment with Docker
+- Security group configuration for PostgreSQL access
+- Route53 DNS record for easy access
+- Random password generation (for admin setup)
+- SSH key pair generation for EC2 access
+- Automated PostgreSQL setup via user data script
+
+## Usage Example
+```hcl
+module "postgres_passwordless" {
+  source                  = "./modules/postgres-passwordless"
+  domain_name             = "example.com"
+  db_name                 = "tfe"
+  db_username             = "tfeadmin"
+  network_id              = var.vpc_id
+  network_public_subnets  = var.public_subnet_ids
+  friendly_name_prefix    = "tfe"
+  aws_iam_instance_profile = var.iam_instance_profile
+}
+```
+
+## Variables
+- `domain_name`: Route 53 hosted zone name for DNS record
+- `db_name`: PostgreSQL database name
+- `db_username`: PostgreSQL username
+- `network_id`: VPC ID for security group
+- `network_public_subnets`: List of public subnet IDs
+- `friendly_name_prefix`: Prefix for resource names
+- `aws_iam_instance_profile`: IAM instance profile for the EC2 instance
+
+## Outputs
+- `postgres_db_endpoint`: The FQDN of the PostgreSQL instance
+- `postgres_db_sg_id`: The security group ID for the PostgreSQL instance
+- `postgres_db_password`: The password for the PostgreSQL instance (sensitive)
+
+## Files Structure
+- `main.tf`: Main Terraform configuration
+- `variables.tf`: Variable definitions
+- `outputs.tf`: Output definitions
+- `data.tf`: Data source definitions
+- `versions.tf`: Provider version constraints
+- `files/fetch_cert_and_start_server.sh`: Script to set up PostgreSQL on EC2
+
+## Notes
+- This module creates an EC2 instance running PostgreSQL in Docker
+- The instance is configured for passwordless authentication patterns
+- A Route53 DNS record is created for easy access
+- SSH access is configured for troubleshooting

--- a/modules/postgres-passwordless/data.tf
+++ b/modules/postgres-passwordless/data.tf
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_route53_zone" "postgres_zone" {
+  name         = var.domain_name
+  private_zone = false
+}

--- a/modules/postgres-passwordless/files/fetch_cert_and_start_server.sh
+++ b/modules/postgres-passwordless/files/fetch_cert_and_start_server.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -eu pipefail
+
+apt-get update -y && apt-get install -y docker.io postgresql-client openssl unzip jq
+systemctl enable --now docker
+usermod -aG docker ubuntu
+
+curl -sS --noproxy '*' "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m | grep -q 'arm\|aarch' && echo 'aarch64' || echo 'x86_64').zip" -o "awscliv2.zip" > /dev/null 2>&1
+unzip -q awscliv2.zip > /dev/null 2>&1
+./aws/install > /dev/null 2>&1
+rm -rf aws awscliv2.zip > /dev/null 2>&1
+
+# For passwordless postgres, we start with basic configuration
+# IAM authentication will be handled at the RDS level
+docker run -d \
+  --name postgres \
+  -p 5432:5432 \
+  -e POSTGRES_USER="$POSTGRES_USER" \
+  -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+  -e POSTGRES_DB="$POSTGRES_DB" \
+  postgres:16
+
+# Wait until PostgreSQL is up
+echo "Waiting for PostgreSQL to become ready..."
+timeout=180
+start=$(date +%s)
+while ! docker exec postgres pg_isready -U "$POSTGRES_USER" >/dev/null 2>&1; do
+  sleep 1
+  [[ $(( $(date +%s) - start )) -gt $timeout ]] && echo "Timeout waiting for PostgreSQL" && docker logs postgres && exit 1
+done
+
+echo "PostgreSQL with passwordless authentication is fully up and running."

--- a/modules/postgres-passwordless/main.tf
+++ b/modules/postgres-passwordless/main.tf
@@ -1,0 +1,113 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# This module provisions a PostgreSQL instance with passwordless authentication (IAM or similar)
+# Adapted from database-mtls module, but without client certs/keys and with passwordless config
+
+resource "random_string" "postgres_db_password" {
+  length           = 128
+  special          = true
+  override_special = "#$%&*"
+}
+
+resource "aws_route53_record" "postgres_db_dns" {
+  zone_id = data.aws_route53_zone.postgres_zone.zone_id
+  name    = "${var.friendly_name_prefix}-postgres-passwordless"
+  type    = "A"
+  ttl     = 300
+
+  records = [aws_instance.postgres_db_instance.public_ip]
+}
+
+resource "aws_security_group" "postgres_db_sg" {
+  description = "The security group of the PostgreSQL deployment for TFE."
+  name        = "${var.friendly_name_prefix}-postgres-passwordless"
+  vpc_id      = var.network_id
+}
+
+resource "aws_security_group_rule" "postgres_db_ingress" {
+  security_group_id = aws_security_group.postgres_db_sg.id
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "postgres_db_ssh_ingress" {
+  security_group_id = aws_security_group.postgres_db_sg.id
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "postgres_db_egress" {
+  security_group_id = aws_security_group.postgres_db_sg.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_instance" "postgres_db_instance" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "m5.xlarge"
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.postgres_db_sg.id]
+  iam_instance_profile        = var.aws_iam_instance_profile
+  key_name                    = aws_key_pair.ec2_key.key_name
+  subnet_id                   = var.network_public_subnets[0]
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 100
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  tags = {
+    Name = "Terraform-Postgres-Passwordless"
+  }
+}
+
+resource "local_file" "postgres_db_private_key" {
+  content         = tls_private_key.postgres_db_ssh_key.private_key_pem
+  filename        = "${path.module}/${var.friendly_name_prefix}-ec2-postgres-key.pem"
+  file_permission = "0600"
+}
+
+resource "tls_private_key" "postgres_db_ssh_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "ec2_key" {
+  key_name   = "${var.friendly_name_prefix}-ec2-postgres-key"
+  public_key = tls_private_key.postgres_db_ssh_key.public_key_openssh
+}
+
+resource "null_resource" "postgres_db_server_start" {
+  depends_on = [aws_route53_record.postgres_db_dns]
+
+  connection {
+    type        = "ssh"
+    user        = "ubuntu"
+    private_key = tls_private_key.postgres_db_ssh_key.private_key_pem
+    host        = aws_route53_record.postgres_db_dns.fqdn
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/fetch_cert_and_start_server.sh"
+    destination = "/home/ubuntu/fetch_cert_and_start_server.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sleep 60",
+      "chmod +x /home/ubuntu/fetch_cert_and_start_server.sh",
+      "sudo POSTGRES_PASSWORD='${random_string.postgres_db_password.result}' POSTGRES_USER=${var.db_username} POSTGRES_DB=${var.db_name} /home/ubuntu/fetch_cert_and_start_server.sh"
+    ]
+  }
+}

--- a/modules/postgres-passwordless/outputs.tf
+++ b/modules/postgres-passwordless/outputs.tf
@@ -1,0 +1,45 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "endpoint" {
+  description = "The connection endpoint of the PostgreSQL instance in address:port format."
+  value       = aws_route53_record.postgres_db_dns.fqdn
+}
+
+output "name" {
+  description = "The name of the PostgreSQL instance."
+  value       = var.db_name
+}
+
+output "password" {
+  description = "The password of the main PostgreSQL user."
+  value       = random_string.postgres_db_password.result
+  sensitive   = true
+}
+
+output "username" {
+  description = "The name of the main PostgreSQL user."
+  value       = var.db_username
+}
+
+output "parameters" {
+  description = "PostgreSQL server parameters for the connection URI."
+  value       = var.db_parameters
+}
+
+# Legacy outputs for backward compatibility
+output "postgres_db_endpoint" {
+  description = "The endpoint of the PostgreSQL instance."
+  value       = aws_route53_record.postgres_db_dns.fqdn
+}
+
+output "postgres_db_sg_id" {
+  description = "The security group ID for the PostgreSQL instance."
+  value       = aws_security_group.postgres_db_sg.id
+}
+
+output "postgres_db_password" {
+  description = "The password for the PostgreSQL instance."
+  value       = random_string.postgres_db_password.result
+  sensitive   = true
+}

--- a/modules/postgres-passwordless/service_accounts/README.md
+++ b/modules/postgres-passwordless/service_accounts/README.md
@@ -1,0 +1,48 @@
+# service_accounts Module for postgres-passwordless
+
+This module creates IAM roles and instance profiles specifically for the PostgreSQL passwordless authentication setup. It provides the necessary permissions for EC2 instances to authenticate with RDS using IAM authentication.
+
+## Features
+- IAM instance profile creation for EC2 instances
+- IAM role with RDS IAM authentication permissions
+- Basic EC2 and CloudWatch permissions
+- Optional KMS permissions for encryption
+- Support for existing IAM roles/profiles
+
+## Usage Example
+```hcl
+module "postgres_passwordless_service_accounts" {
+  source = "./modules/postgres-passwordless/service_accounts"
+  
+  friendly_name_prefix     = "tfe"
+  db_instance_identifier   = "tfe-postgres"
+  db_username             = "tfeadmin"
+  kms_key_arn             = var.kms_key_arn
+}
+```
+
+## Variables
+- `friendly_name_prefix`: Prefix for resource names
+- `db_instance_identifier`: RDS instance identifier for IAM auth
+- `db_username`: Database username for IAM auth
+- `existing_iam_instance_profile_name`: Use existing profile (optional)
+- `existing_iam_instance_role_name`: Use existing role (optional)
+- `iam_role_policy_arns`: Additional policy ARNs to attach
+- `kms_key_arn`: KMS key ARN for encryption (optional)
+
+## Outputs
+- `iam_instance_profile`: The IAM instance profile object
+- `iam_instance_profile_name`: The name of the IAM instance profile
+- `iam_role`: The IAM role object
+- `iam_role_name`: The name of the IAM role
+
+## Permissions Included
+- `rds-db:connect` for IAM database authentication
+- Basic EC2 and CloudWatch permissions
+- Optional KMS permissions for encryption
+- Support for additional custom policies
+
+## Notes
+- This module is specifically designed for passwordless PostgreSQL authentication
+- The RDS IAM authentication policy is scoped to the specific database and user
+- KMS permissions are only created if a KMS key ARN is provided

--- a/modules/postgres-passwordless/service_accounts/data.tf
+++ b/modules/postgres-passwordless/service_accounts/data.tf
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "aws_iam_instance_profile" "existing_instance_profile" {
+  count = var.existing_iam_instance_profile_name != null ? 1 : 0
+
+  name = var.existing_iam_instance_profile_name
+}
+
+data "aws_iam_role" "existing_instance_role" {
+  count = var.existing_iam_instance_role_name != null ? 1 : 0
+
+  name = var.existing_iam_instance_role_name
+}

--- a/modules/postgres-passwordless/service_accounts/locals.tf
+++ b/modules/postgres-passwordless/service_accounts/locals.tf
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+locals {
+  iam_instance_role    = try(data.aws_iam_role.existing_instance_role[0], aws_iam_role.instance_role[0])
+  iam_instance_profile = try(data.aws_iam_instance_profile.existing_instance_profile[0], aws_iam_instance_profile.postgres_passwordless[0])
+}

--- a/modules/postgres-passwordless/service_accounts/main.tf
+++ b/modules/postgres-passwordless/service_accounts/main.tf
@@ -1,0 +1,122 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_iam_instance_profile" "postgres_passwordless" {
+  count = var.existing_iam_instance_profile_name == null ? 1 : 0
+
+  name_prefix = "${var.friendly_name_prefix}-postgres-passwordless"
+  role        = local.iam_instance_role.name
+}
+
+resource "aws_iam_role" "instance_role" {
+  count = var.existing_iam_instance_role_name == null ? 1 : 0
+
+  name_prefix        = "${var.friendly_name_prefix}-postgres-passwordless"
+  assume_role_policy = data.aws_iam_policy_document.instance_role[0].json
+}
+
+data "aws_iam_policy_document" "instance_role" {
+  count = var.existing_iam_instance_profile_name == null ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# RDS IAM authentication policy for passwordless database access
+resource "aws_iam_role_policy" "rds_iam_auth" {
+  count = var.existing_iam_instance_profile_name == null ? 1 : 0
+
+  policy = data.aws_iam_policy_document.rds_iam_auth[0].json
+  role   = local.iam_instance_role.id
+
+  name = "${var.friendly_name_prefix}-postgres-passwordless-rds-auth"
+}
+
+data "aws_iam_policy_document" "rds_iam_auth" {
+  count = var.existing_iam_instance_profile_name == null ? 1 : 0
+
+  statement {
+    actions = [
+      "rds-db:connect"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:rds-db:*:*:dbuser:${var.db_instance_identifier}/${var.db_username}"
+    ]
+    sid = "AllowRDSIAMAuthentication"
+  }
+}
+
+# Basic EC2 and CloudWatch permissions
+resource "aws_iam_role_policy" "basic_permissions" {
+  count = var.existing_iam_instance_profile_name == null ? 1 : 0
+
+  policy = data.aws_iam_policy_document.basic_permissions[0].json
+  role   = local.iam_instance_role.id
+
+  name = "${var.friendly_name_prefix}-postgres-passwordless-basic"
+}
+
+data "aws_iam_policy_document" "basic_permissions" {
+  count = var.existing_iam_instance_profile_name == null ? 1 : 0
+
+  statement {
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:DescribeTags",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "AllowBasicEC2AndCloudWatchAccess"
+  }
+}
+
+# This will allow you to add any additional policies you may need, regardless
+# of whether you're using an existing role and instance profile.
+resource "aws_iam_role_policy_attachment" "misc" {
+  for_each = var.iam_role_policy_arns
+
+  role       = local.iam_instance_role.name
+  policy_arn = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "kms_policy" {
+  count = var.existing_iam_instance_profile_name == null && var.kms_key_arn != null ? 1 : 0
+
+  role       = local.iam_instance_role.name
+  policy_arn = aws_iam_policy.kms_policy[0].arn
+}
+
+resource "aws_iam_policy" "kms_policy" {
+  count = var.existing_iam_instance_profile_name == null && var.kms_key_arn != null ? 1 : 0
+
+  name = "${var.friendly_name_prefix}-postgres-passwordless-kms"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+        ]
+        Effect   = "Allow"
+        Resource = var.kms_key_arn
+      },
+    ]
+  })
+}

--- a/modules/postgres-passwordless/service_accounts/outputs.tf
+++ b/modules/postgres-passwordless/service_accounts/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "iam_instance_profile" {
+  description = "The IAM instance profile that will be attached to the PostgreSQL EC2 instance."
+  value       = local.iam_instance_profile
+}
+
+output "iam_instance_profile_name" {
+  description = "The name of the IAM instance profile that will be attached to the PostgreSQL EC2 instance."
+  value       = local.iam_instance_profile.name
+}
+
+output "iam_role" {
+  description = "The IAM role associated with the PostgreSQL EC2 instance."
+  value       = local.iam_instance_role
+}
+
+output "iam_role_name" {
+  description = "The name of the IAM role associated with the PostgreSQL EC2 instance."
+  value       = local.iam_instance_role.name
+}

--- a/modules/postgres-passwordless/service_accounts/variables.tf
+++ b/modules/postgres-passwordless/service_accounts/variables.tf
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "existing_iam_instance_profile_name" {
+  description = "The IAM instance profile to be attached to the PostgreSQL EC2 instance. Leave the value null to create a new one."
+  type        = string
+  default     = null
+}
+
+variable "existing_iam_instance_role_name" {
+  type        = string
+  description = "The IAM role to associate with the instance profile. To create a new role, this value should be null."
+  default     = null
+}
+
+variable "friendly_name_prefix" {
+  type        = string
+  description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
+}
+
+variable "iam_role_policy_arns" {
+  default     = []
+  description = "A set of Amazon Resource Names of IAM role policies to be attached to the PostgreSQL IAM role."
+  type        = set(string)
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "KMS key arn for AWS KMS Customer managed key. Set to null if not using KMS."
+  default     = null
+}
+
+variable "db_instance_identifier" {
+  type        = string
+  description = "The RDS instance identifier for IAM authentication. Used in the RDS IAM policy."
+}
+
+variable "db_username" {
+  type        = string
+  description = "The database username for IAM authentication. Used in the RDS IAM policy."
+}

--- a/modules/postgres-passwordless/service_accounts/versions.tf
+++ b/modules/postgres-passwordless/service_accounts/versions.tf
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/modules/postgres-passwordless/variables.tf
+++ b/modules/postgres-passwordless/variables.tf
@@ -1,0 +1,44 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "domain_name" {
+  description = "The name of the Route 53 Hosted Zone in which a record will be created."
+  type        = string
+}
+
+variable "db_name" {
+  type        = string
+  description = "PostgreSQL instance name. No special characters."
+}
+
+variable "db_username" {
+  type        = string
+  description = "PostgreSQL instance username. No special characters."
+}
+
+variable "db_parameters" {
+  type        = string
+  description = "PostgreSQL server parameters for the connection URI. Used to configure the PostgreSQL connection (e.g. sslmode=require)."
+  default     = ""
+}
+
+variable "network_id" {
+  description = "The identity of the VPC in which the security group attached to the PostgreSQL instance will be deployed."
+  type        = string
+}
+
+variable "network_public_subnets" {
+  default     = []
+  description = "A list of the identities of the public subnetworks in which resources will be deployed."
+  type        = list(string)
+}
+
+variable "friendly_name_prefix" {
+  type        = string
+  description = "(Required) Friendly name prefix used for tagging and naming AWS resources."
+}
+
+variable "aws_iam_instance_profile" {
+  description = "The AWS IAM instance profile name to be attached to the instance."
+  type        = string
+}

--- a/modules/postgres-passwordless/versions.tf
+++ b/modules/postgres-passwordless/versions.tf
@@ -1,0 +1,28 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -270,6 +270,18 @@ variable "db_use_mtls" {
   default     = false
 }
 
+variable "postgres_enable_iam_auth" {
+  type        = bool
+  description = "Whether to enable IAM authentication for PostgreSQL. Used for passwordless authentication."
+  default     = false
+}
+
+variable "postgres_use_password_auth" {
+  type        = bool
+  description = "Whether to use password authentication for PostgreSQL. Set to false for passwordless authentication."
+  default     = true
+}
+
 variable "postgres_ca_certificate_secret_id" {
   type        = string
   description = "The secrets manager secret ID of the Base64 & PEM encoded certificate for postgres."


### PR DESCRIPTION
- Add postgres-passwordless module with IAM authentication
- Update database module to support IAM authentication options
- Add variables for enabling postgres passwordless mode
- Update main module integration for postgres passwordless


## Background

This enables PostgreSQL database authentication using AWS IAM instead of traditional username/password authentication.


Relates OR Closes https://github.com/hashicorp/terraform-enterprise/pull/3079


## How Has This Been Tested

CI/CD: https://github.com/hashicorp/terraform-enterprise/actions/runs/18079265431/job/51440243884


